### PR TITLE
Compatibility of add_object with GRAVITY format

### DIFF
--- a/docs/species.data.rst
+++ b/docs/species.data.rst
@@ -60,6 +60,14 @@ species.data.drift\_phoenix module
     :undoc-members:
     :show-inheritance:
 
+species.data.exo\_rem module
+----------------------------
+
+.. automodule:: species.data.exo_rem
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 species.data.filters module
 ---------------------------
 

--- a/species/data/database.py
+++ b/species/data/database.py
@@ -471,8 +471,8 @@ class Database:
             h5_file.create_dataset(f'objects/{object_name}/distance',
                                    data=distance)  # (pc)
 
-            flux = {}
-            error = {}
+        flux = {}
+        error = {}
 
         if app_mag is not None:
             for item in app_mag:

--- a/species/data/vega.py
+++ b/species/data/vega.py
@@ -10,9 +10,10 @@ import numpy as np
 from astropy.io import fits
 
 
-def add_vega(input_path, database):
+def add_vega(input_path,
+             database):
     """
-    Function for adding a Vega spectrum to the database.
+    Function for adding a flux-calibrated spectrum of Vega to the database.
 
     Parameters
     ----------


### PR DESCRIPTION
Added compatibility of the `add_object` function of `Database` with the GRAVITY format. The FITS cube with the spectrum and covariance matrix can be provided twice, instead of using a separate file for the spectrum and covariances. For example:

``database.add_object('planet name', distance=(20., 0.1), app_mag=None, spectrum={'GRAVITY': ('data.fits', data.fits')})``

Also additional output is printed.