### PR TITLE
Parameter estimation with nested sampling

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,7 @@ Documentation can be found at `http://species.readthedocs.io <http://species.rea
 Attribution
 -----------
 
-Please cite `Stolker et al. (2020) <https://ui.adsabs.harvard.edu/abs/2019arXiv191213316S/abstract/>`_ whenever results from *species* are used in a publication. Please also make sure to give credit to the relevant papers regarding the use of the publicly available data that *species* benefits from. The *species* logo is `available <https://people.phys.ethz.ch/~stolkert/species/species_logo.zip>`_ for use in presentations.
+Please cite `Stolker et al. (2020) <https://ui.adsabs.harvard.edu/abs/2020A%26A...635A.182S/abstract>`_ whenever results from *species* are used in a publication. Please also make sure to give credit to the relevant papers regarding the use of the publicly available data that *species* benefits from. The *species* logo is `available <https://people.phys.ethz.ch/~stolkert/species/species_logo.zip>`_ for use in presentations.
 
 Contributing
 ------------

--- a/docs/about.rst
+++ b/docs/about.rst
@@ -11,4 +11,4 @@ Questions & feedback
 Attribution
 -----------
 
-Please cite `Stolker et al. (2020) <https://ui.adsabs.harvard.edu/abs/2019arXiv191213316S/abstract>`_ whenever results from *species* are used in a publication. Please also make sure to give credit the relevant papers regarding the use of the publicly available data that *species* is using, such as the photometric and spectral libraries, atmospheric models, evolutionary models, and photometry of individual objects. The *species* logo is `available <https://people.phys.ethz.ch/~stolkert/species/species_logo.zip>`_ for use in presentations.
+Please cite `Stolker et al. (2020) <https://ui.adsabs.harvard.edu/abs/2020A%26A...635A.182S/abstract>`_ whenever results from *species* are used in a publication. Please also make sure to give credit the relevant papers regarding the use of the publicly available data that *species* is using, such as the photometric and spectral libraries, atmospheric models, evolutionary models, and photometry of individual objects. The *species* logo is `available <https://people.phys.ethz.ch/~stolkert/species/species_logo.zip>`_ for use in presentations.

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,5 @@ pandas ~= 0.25
 pymultinest ~= 2.9
 scipy ~= 1.4
 spectres ~= 2.0
-tqdm ~= 4.43
+tqdm ~= 4.45
 xlrd ~= 1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,6 @@ numpy ~= 1.18
 pandas ~= 0.25
 pymultinest ~= 2.9
 scipy ~= 1.4
-spectres ~= 2.0
+spectres ~= 2.1
 tqdm ~= 4.45
 xlrd ~= 1.2

--- a/species/analysis/fit_planck.py
+++ b/species/analysis/fit_planck.py
@@ -104,9 +104,9 @@ def lnlike(param,
 
             model = readplanck.get_spectrum(paramdict, 100.)
 
-            flux_new = spectres.spectres(new_spec_wavs=spectrum[item][0][:, 0],
-                                         old_spec_wavs=model.wavelength,
-                                         spec_fluxes=model.flux,
+            flux_new = spectres.spectres(spectrum[item][0][:, 0],
+                                         model.wavelength,
+                                         model.flux,
                                          spec_errs=None)
 
             if spectrum[item][1] is not None:
@@ -321,21 +321,25 @@ class FitPlanck:
                                                   size=nwalkers)
 
         with Pool(processes=cpu_count()):
-            sampler = emcee.EnsembleSampler(nwalkers,
-                                            ndim,
-                                            lnprob,
-                                            args=([self.bounds,
-                                                   self.objphot,
-                                                   self.synphot,
-                                                   self.distance[0],
-                                                   self.spectrum]))
+            ens_sampler = emcee.EnsembleSampler(nwalkers,
+                                                ndim,
+                                                lnprob,
+                                                args=([self.bounds,
+                                                       self.objphot,
+                                                       self.synphot,
+                                                       self.distance[0],
+                                                       self.spectrum]))
 
-            sampler.run_mcmc(initial, nsteps, progress=True)
+            ens_sampler.run_mcmc(initial, nsteps, progress=True)
 
         species_db = database.Database()
 
-        species_db.add_samples(sampler=sampler,
+        species_db.add_samples(sampler='emcee',
+                               samples=ens_sampler.chain,
+                               ln_prob=ens_sampler.lnprobability,
+                               mean_accept=np.mean(ens_sampler.acceptance_fraction),
                                spectrum=('model', self.model),
                                tag=tag,
                                modelpar=self.modelpar,
-                               distance=self.distance[0])
+                               distance=self.distance[0],
+                               spec_labels=None)

--- a/species/analysis/fit_spectrum.py
+++ b/species/analysis/fit_spectrum.py
@@ -178,21 +178,25 @@ class FitSpectrum:
                 self.bounds['scaling'+str(i)] = (0., 1e2)
 
         with Pool(processes=cpu_count()):
-            sampler = emcee.EnsembleSampler(nwalkers,
-                                            ndim,
-                                            lnprob,
-                                            args=([self.bounds,
-                                                   self.modelpar,
-                                                   self.objphot,
-                                                   self.specphot,
-                                                   bands]))
+            ens_sampler = emcee.EnsembleSampler(nwalkers,
+                                                ndim,
+                                                lnprob,
+                                                args=([self.bounds,
+                                                       self.modelpar,
+                                                       self.objphot,
+                                                       self.specphot,
+                                                       bands]))
 
-            sampler.run_mcmc(initial, nsteps, progress=True)
+            ens_sampler.run_mcmc(initial, nsteps, progress=True)
 
         species_db = database.Database()
 
-        species_db.add_samples(sampler=sampler,
+        species_db.add_samples(sampler='emcee',
+                               samples=ens_sampler.chain,
+                               ln_prob=ens_sampler.lnprobability,
+                               mean_accept=np.mean(ens_sampler.acceptance_fraction),
                                spectrum=('calibration', self.spectrum),
                                tag=tag,
                                modelpar=self.modelpar,
-                               distance=None)
+                               distance=None,
+                               spec_labels=None)

--- a/species/data/companions.py
+++ b/species/data/companions.py
@@ -100,8 +100,8 @@ def get_data():
             'PDS 70 b': {'distance': (113.43, 0.52),
                          'app_mag': {'Paranal/SPHERE.IRDIS_D_H23_2': (17.94, 0.24),  # Keppler et al. 2018
                                      'Paranal/SPHERE.IRDIS_D_H23_3': (17.95, 0.17),  # Keppler et al. 2018
-                                     'Paranal/SPHERE.IRDIS_D_K12_1': (16.49, 0.41),  # Stolker et al. in prep.
-                                     'Paranal/SPHERE.IRDIS_D_K12_2': (16.54, 0.52),  # Stolker et al. in prep.
+                                     'Paranal/SPHERE.IRDIS_D_K12_1': (16.78, 0.31),  # Stolker et al. in prep.
+                                     'Paranal/SPHERE.IRDIS_D_K12_2': (16.23, 0.32),  # Stolker et al. in prep.
                                      'Paranal/NACO.Lp': (14.08, 0.33),  # Stolker et al. in prep.
                                      'Paranal/NACO.NB405': (13.91, 0.34),  # Stolker et al. in prep.
                                      'Paranal/NACO.Mp': (13.64, 0.22)}},  # Stolker et al. in prep.

--- a/species/data/database.py
+++ b/species/data/database.py
@@ -828,6 +828,9 @@ class Database:
 
     def add_samples(self,
                     sampler,
+                    samples,
+                    ln_prob,
+                    mean_accept,
                     spectrum,
                     tag,
                     modelpar,
@@ -862,21 +865,23 @@ class Database:
         if 'results' not in h5_file:
             h5_file.create_group('results')
 
-        if 'results/mcmc' not in h5_file:
-            h5_file.create_group('results/mcmc')
+        if 'results/fit' not in h5_file:
+            h5_file.create_group('results/fit')
 
-        if f'results/mcmc/{tag}' in h5_file:
-            del h5_file[f'results/mcmc/{tag}']
+        if f'results/fit/{tag}' in h5_file:
+            del h5_file[f'results/fit/{tag}']
 
-        dset = h5_file.create_dataset(f'results/mcmc/{tag}/samples',
-                                      data=sampler.chain)
-
-        h5_file.create_dataset(f'results/mcmc/{tag}/probability',
-                               data=np.exp(sampler.lnprobability))
+        dset = h5_file.create_dataset(f'results/fit/{tag}/samples', data=samples)
+        h5_file.create_dataset(f'results/fit/{tag}/ln_prob', data=ln_prob)
 
         dset.attrs['type'] = str(spectrum[0])
         dset.attrs['spectrum'] = str(spectrum[1])
         dset.attrs['n_param'] = int(len(modelpar))
+        dset.attrs['sampler'] = str(sampler)
+
+        if mean_accept is not None:
+            dset.attrs['mean_accept'] = float(mean_accept)
+            print(f'Mean acceptance fraction: {mean_accept:.3f}')
 
         if distance:
             dset.attrs['distance'] = float(distance)
@@ -892,12 +897,8 @@ class Database:
 
         dset.attrs['n_scaling'] = int(count_scaling)
 
-        mean_accep = np.mean(sampler.acceptance_fraction)
-        dset.attrs['acceptance'] = float(mean_accep)
-        print(f'Mean acceptance fraction: {mean_accep:.3f}')
-
         try:
-            int_auto = emcee.autocorr.integrated_time(sampler.flatchain)
+            int_auto = emcee.autocorr.integrated_time(samples)
             print(f'Integrated autocorrelation time = {int_auto}')
 
         except emcee.autocorr.AutocorrError:
@@ -932,22 +933,30 @@ class Database:
         """
 
         h5_file = h5py.File(self.database, 'r')
-        dset = h5_file[f'results/mcmc/{tag}/samples']
+        dset = h5_file[f'results/fit/{tag}/samples']
 
         samples = np.asarray(dset)
-        samples = samples[:, burnin:, :]
-
-        probability = np.asarray(h5_file[f'results/mcmc/{tag}/probability'])
-        probability = probability[:, burnin:]
+        ln_prob = np.asarray(h5_file[f'results/fit/{tag}/ln_prob'])
 
         if 'n_param' in dset.attrs:
             n_param = dset.attrs['n_param']
         elif 'nparam' in dset.attrs:
             n_param = dset.attrs['nparam']
 
-        index_max = np.unravel_index(probability.argmax(), probability.shape)
+        if samples.ndim == 3:
+            if burnin > samples.shape[1]:
+                raise ValueError(f'The \'burnin\' value is larger than the number of steps '
+                                 f'({samples.shape[1]}) that are made by the walkers.')
 
-        # max_prob = probability[index_max]
+            samples = samples[:, burnin:, :]
+            ln_prob = ln_prob[:, burnin:]
+
+            samples = np.reshape(samples, (-1, n_param))
+            ln_prob = np.reshape(ln_prob,  -1)
+
+        index_max = np.unravel_index(ln_prob.argmax(), ln_prob.shape)
+
+        # max_prob = ln_prob[index_max]
         max_sample = samples[index_max]
 
         prob_sample = {}
@@ -985,7 +994,7 @@ class Database:
         """
 
         with h5py.File(self.database, 'r') as h5_file:
-            dset = h5_file[f'results/mcmc/{tag}/samples']
+            dset = h5_file[f'results/fit/{tag}/samples']
 
             if 'n_param' in dset.attrs:
                 n_param = dset.attrs['n_param']
@@ -995,6 +1004,10 @@ class Database:
             samples = np.asarray(dset)
 
             if samples.ndim == 3:
+                if burnin > samples.shape[1]:
+                    raise ValueError(f'The \'burnin\' value is larger than the number of steps '
+                                     f'({samples.shape[1]}) that are made by the walkers.')
+
                 if burnin is not None:
                     samples = samples[:, burnin:, :]
 
@@ -1040,7 +1053,7 @@ class Database:
         """
 
         h5_file = h5py.File(self.database, 'r')
-        dset = h5_file[f'results/mcmc/{tag}/samples']
+        dset = h5_file[f'results/fit/{tag}/samples']
 
         spectrum_type = dset.attrs['type']
         spectrum_name = dset.attrs['spectrum']
@@ -1080,11 +1093,21 @@ class Database:
             distance = None
 
         samples = np.asarray(dset)
-        samples = samples[:, burnin:, :]
 
-        ran_walker = np.random.randint(samples.shape[0], size=random)
-        ran_step = np.random.randint(samples.shape[1], size=random)
-        samples = samples[ran_walker, ran_step, :]
+        if samples.ndim == 2:
+            ran_index = np.random.randint(samples.shape[0], size=random)
+            samples = samples[ran_index, ]
+
+        elif samples.ndim == 3:
+            if burnin > samples.shape[1]:
+                raise ValueError(f'The \'burnin\' value is larger than the number of steps '
+                                 f'({samples.shape[1]}) that are made by the walkers.')
+
+            samples = samples[:, burnin:, :]
+
+            ran_walker = np.random.randint(samples.shape[0], size=random)
+            ran_step = np.random.randint(samples.shape[1], size=random)
+            samples = samples[ran_walker, ran_step, :]
 
         param = []
         for i in range(n_param):
@@ -1148,7 +1171,7 @@ class Database:
         """
 
         h5_file = h5py.File(self.database, 'r')
-        dset = h5_file[f'results/mcmc/{tag}/samples']
+        dset = h5_file[f'results/fit/{tag}/samples']
 
         if 'n_param' in dset.attrs:
             n_param = dset.attrs['n_param']
@@ -1316,7 +1339,7 @@ class Database:
             burnin = 0
 
         h5_file = h5py.File(self.database, 'r')
-        dset = h5_file[f'results/mcmc/{tag}/samples']
+        dset = h5_file[f'results/fit/{tag}/samples']
 
         spectrum = dset.attrs['spectrum']
 
@@ -1328,6 +1351,10 @@ class Database:
         samples = np.asarray(dset)
 
         if samples.ndim == 3:
+            if burnin > samples.shape[1]:
+                raise ValueError(f'The \'burnin\' value is larger than the number of steps '
+                                 f'({samples.shape[1]}) that are made by the walkers.')
+
             samples = samples[:, burnin:, :]
 
             if random:
@@ -1387,11 +1414,11 @@ class Database:
     #         if 'results' not in h5_file:
     #             h5_file.create_group('results')
     #
-    #         if 'results/mcmc' not in h5_file:
-    #             h5_file.create_group('results/mcmc')
+    #         if 'results/fit' not in h5_file:
+    #             h5_file.create_group('results/fit')
     #
-    #         if f'results/mcmc/{tag}' in h5_file:
-    #             del h5_file[f'results/mcmc/{tag}']
+    #         if f'results/fit/{tag}' in h5_file:
+    #             del h5_file[f'results/fit/{tag}']
     #
     #         # remove the column with the log-likelihood value
     #         samples = samples[:, :-1]
@@ -1400,7 +1427,7 @@ class Database:
     #             raise ValueError('The number of parameters is not equal to the parameter size '
     #                              'of the samples array.')
     #
-    #         dset = h5_file.create_dataset(f'results/mcmc/{tag}/samples', data=samples)
+    #         dset = h5_file.create_dataset(f'results/fit/{tag}/samples', data=samples)
     #
     #         dset.attrs['type'] = 'model'
     #         dset.attrs['spectrum'] = 'petitradtrans'
@@ -1473,7 +1500,7 @@ class Database:
     #     database_path = config['species']['database']
     #
     #     h5_file = h5py.File(database_path, 'r')
-    #     dset = h5_file[f'results/mcmc/{tag}/samples']
+    #     dset = h5_file[f'results/fit/{tag}/samples']
     #
     #     spectrum_type = dset.attrs['type']
     #     spectrum_name = dset.attrs['spectrum']

--- a/species/data/database.py
+++ b/species/data/database.py
@@ -275,8 +275,8 @@ class Database:
             Effective temperature range (K). Setting the value to None for will add all available
             temperatures.
         data_folder : str, None
-            Folder with input data. Only required for the Exo-REM and petitCODE hot models which
-            are not publicly available.
+            Folder with input data. Only required for the petitCODE hot models which are not
+            publicly available.
 
         Returns
         -------
@@ -284,7 +284,7 @@ class Database:
             None
         """
 
-        proprietary = ['petitcode-hot-clear', 'petitcode-hot-cloudy', 'exo-rem']
+        proprietary = ['petitcode-hot-clear', 'petitcode-hot-cloudy']
 
         if model in proprietary and data_folder is None:
             raise ValueError(f'The {model} model is not publicly available and needs to '
@@ -394,7 +394,6 @@ class Database:
         elif model == 'exo-rem':
             exo_rem.add_exo_rem(self.input_path,
                                 h5_file,
-                                data_folder,
                                 wavel_range,
                                 teff_range,
                                 spec_res)

--- a/species/data/exo_rem.py
+++ b/species/data/exo_rem.py
@@ -3,7 +3,7 @@ Module for Exo-REM atmospheric model spectra.
 """
 
 import os
-import zipfile
+import tarfile
 import warnings
 import urllib.request
 
@@ -16,7 +16,6 @@ from species.util import data_util
 
 def add_exo_rem(input_path,
                 database,
-                data_folder,
                 wavel_range=None,
                 teff_range=None,
                 spec_res=1000.):
@@ -29,8 +28,6 @@ def add_exo_rem(input_path,
         Folder where the data is located.
     database : h5py._hl.files.File
         Database.
-    data_folder : str
-        Path with input data.
     wavel_range : tuple(float, float), None
         Wavelength range (um). The original wavelength points are used if set to None.
     teff_range : tuple(float, float), None
@@ -47,6 +44,29 @@ def add_exo_rem(input_path,
     if not os.path.exists(input_path):
         os.makedirs(input_path)
 
+    data_folder = os.path.join(input_path, 'exo-rem/')
+
+    if not os.path.exists(data_folder):
+        os.makedirs(data_folder)
+
+    input_file = 'exorem.tgz'
+    label = '(160 MB)'
+
+    url = 'https://people.phys.ethz.ch/~ipa/tstolker/exorem.tgz'
+
+    data_file = os.path.join(data_folder, input_file)
+
+    if not os.path.isfile(data_file):
+        print(f'Downloading Exo-REM model spectra {label}...', end='', flush=True)
+        urllib.request.urlretrieve(url, data_file)
+        print(' [DONE]')
+
+    print(f'Unpacking Exo-REM model spectra {label}...', end='', flush=True)
+    tar = tarfile.open(data_file)
+    tar.extractall(data_folder)
+    tar.close()
+    print(' [DONE]')
+
     teff = []
     logg = []
     feh = []
@@ -57,6 +77,7 @@ def add_exo_rem(input_path,
         wavelength = [wavel_range[0]]
 
         while wavelength[-1] <= wavel_range[1]:
+            # From Paul Mollière:
             # resolution = lambda / (resolution element of the spectrograph)
             # R = lambda / delta_lambda / 2, because twice as many points as R to actually resolve
             # two features that are lambda / R apart

--- a/species/plot/plot_mcmc.py
+++ b/species/plot/plot_mcmc.py
@@ -32,10 +32,10 @@ def plot_walkers(tag,
     ----------
     tag : str
         Database tag with the MCMC samples.
-    nsteps : int
-        Number of steps.
-    offset : tuple(float, float)
-        Offset of the x- and y-axis label.
+    nsteps : int, None
+        Number of steps that are plotted.
+    offset : tuple(float, float), None
+        Offset of the x- and y-axis label. Not used if set to None.
     output : str
         Output filename.
 

--- a/species/read/read_calibration.py
+++ b/species/read/read_calibration.py
@@ -89,7 +89,9 @@ class ReadCalibration:
         flux_new, error_new = spectres.spectres(wavel_points,
                                                 calibbox.wavelength,
                                                 calibbox.flux,
-                                                spec_errs=calibbox.error)
+                                                spec_errs=calibbox.error,
+                                                fill=0.,
+                                                verbose=False)
 
         if model_param is not None:
             flux_new = model_param['scaling']*flux_new
@@ -217,7 +219,9 @@ class ReadCalibration:
                     flux_new, error_new = spectres.spectres(wavelength_new,
                                                             wavelength,
                                                             flux,
-                                                            spec_errs=error)
+                                                            spec_errs=error,
+                                                            fill=0.,
+                                                            verbose=False)
 
                     value_error = False
 

--- a/species/read/read_calibration.py
+++ b/species/read/read_calibration.py
@@ -86,9 +86,9 @@ class ReadCalibration:
             calibbox.flux = calibbox.flux[indices]
             calibbox.error = calibbox.error[indices]
 
-        flux_new, error_new = spectres.spectres(new_spec_wavs=wavel_points,
-                                                old_spec_wavs=calibbox.wavelength,
-                                                spec_fluxes=calibbox.flux,
+        flux_new, error_new = spectres.spectres(wavel_points,
+                                                calibbox.wavelength,
+                                                calibbox.flux,
                                                 spec_errs=calibbox.error)
 
         if model_param is not None:
@@ -214,9 +214,9 @@ class ReadCalibration:
 
             while value_error:
                 try:
-                    flux_new, error_new = spectres.spectres(new_spec_wavs=wavelength_new,
-                                                            old_spec_wavs=wavelength,
-                                                            spec_fluxes=flux,
+                    flux_new, error_new = spectres.spectres(wavelength_new,
+                                                            wavelength,
+                                                            flux,
                                                             spec_errs=error)
 
                     value_error = False

--- a/species/read/read_model.py
+++ b/species/read/read_model.py
@@ -414,9 +414,9 @@ class ReadModel:
                                              spec_res=spec_res)
 
         if wavel_resample is not None:
-            flux = spectres.spectres(new_spec_wavs=wavel_resample,
-                                     old_spec_wavs=self.wl_points,
-                                     spec_fluxes=flux)
+            flux = spectres.spectres(wavel_resample,
+                                     self.wl_points,
+                                     flux)
 
         elif spec_res is not None:
             index = np.where(np.isnan(flux))[0]
@@ -440,9 +440,9 @@ class ReadModel:
                 try:
                     index_error = False
 
-                    flux = spectres.spectres(new_spec_wavs=wavel_resample[indices][i:-i],
-                                             old_spec_wavs=self.wl_points,
-                                             spec_fluxes=flux)
+                    flux = spectres.spectres(wavel_resample[indices][i:-i],
+                                             self.wl_points,
+                                             flux)
 
                 except ValueError:
                     index_error = True
@@ -472,9 +472,9 @@ class ReadModel:
             else:
                 new_spec_wavs = self.wl_points
 
-            flux_vega, _ = spectres.spectres(new_spec_wavs=new_spec_wavs,
-                                             old_spec_wavs=calibbox.wavelength,
-                                             spec_fluxes=calibbox.flux,
+            flux_vega, _ = spectres.spectres(new_spec_wavs,
+                                             calibbox.wavelength,
+                                             calibbox.flux,
                                              spec_errs=calibbox.error)
 
             flux = -2.5*np.log10(flux/flux_vega)

--- a/species/read/read_model.py
+++ b/species/read/read_model.py
@@ -491,15 +491,22 @@ class ReadModel:
 
         if wavelength.shape[0] == 0:
             raise ValueError(f'The model spectrum is empty. Perhaps the grid could not be '
-                             f'interpolated at {model_param} because NaNs are stored in the '
+                             f'interpolated at {model_param} because zeros are stored in the '
                              f'database.')
 
-        return box.create_box(boxtype='model',
-                              model=self.model,
-                              wavelength=wavelength,
-                              flux=flux[is_finite],
-                              parameters=model_param,
-                              quantity=quantity)
+        spec_box = box.create_box(boxtype='model',
+                                  model=self.model,
+                                  wavelength=wavelength,
+                                  flux=flux[is_finite],
+                                  parameters=model_param,
+                                  quantity=quantity)
+
+        if 'radius' in spec_box.parameters:
+            spec_box.parameters['luminosity'] = 4. * np.pi * (spec_box.parameters['radius'] * \
+                constants.R_JUP)**2 * constants.SIGMA_SB * spec_box.parameters['teff']**4. / \
+                constants.L_SUN  # (Lsun)
+
+        return spec_box
 
     def get_data(self,
                  model_param):
@@ -585,12 +592,19 @@ class ReadModel:
 
         h5_file.close()
 
-        return box.create_box(boxtype='model',
-                              model=self.model,
-                              wavelength=wl_points,
-                              flux=flux,
-                              parameters=model_param,
-                              quantity='flux')
+        spec_box = box.create_box(boxtype='model',
+                                  model=self.model,
+                                  wavelength=wl_points,
+                                  flux=flux,
+                                  parameters=model_param,
+                                  quantity='flux')
+
+        if 'radius' in spec_box.parameters:
+            spec_box.parameters['luminosity'] = 4. * np.pi * (spec_box.parameters['radius'] * \
+                constants.R_JUP)**2 * constants.SIGMA_SB * spec_box.parameters['teff']**4. / \
+                constants.L_SUN  # (Lsun)
+
+        return spec_box
 
     def get_flux(self,
                  model_param,

--- a/species/util/data_util.py
+++ b/species/util/data_util.py
@@ -289,7 +289,7 @@ def add_missing(model,
         points = np.asarray(points)
         new_points = np.asarray(new_points)
 
-        test = griddata(points.T, values, new_points.T, method='nearest')
+        test = griddata(points.T, values, new_points.T, method='linear')
 
         for item in test:
             if np.isnan(item[0]):

--- a/species/util/data_util.py
+++ b/species/util/data_util.py
@@ -220,6 +220,8 @@ def add_missing(model,
                 parameters,
                 database):
     """
+    Function for adding missing grid points by linearly interpolating the available grid points.
+
     Parameters
     ----------
     model : str
@@ -254,12 +256,102 @@ def add_missing(model,
 
     print('Fixing missing grid points:')
 
-    if len(parameters) == 4:
+    if len(parameters) == 2:
+        find_missing = np.zeros(grid_shape, dtype=bool)
+
+        values = []
+        points = [[], []]
+        new_points = [[], []]
+
+        new_flux = np.zeros((grid_shape[0], grid_shape[1], wavelength.shape[0]))
+
+        for i in range(grid_shape[0]):
+            for j in range(grid_shape[1]):
+                if np.count_nonzero(flux[i, j, ...]) == 0:
+                    find_missing[i, j] = True
+
+                else:
+                    points[0].append(param_data[0][i])
+                    points[1].append(param_data[1][j])
+
+                    values.append(flux[i, j, ...])
+
+                new_points[0].append(param_data[0][i])
+                new_points[1].append(param_data[1][j])
+
+                count_total += 1
+
+        values = np.asarray(values)
+        points = np.asarray(points)
+        new_points = np.asarray(new_points)
+
+        test = griddata(points.T, values, new_points.T, method='linear')
+
+        for item in test:
+            if np.isnan(item[0]):
+                count_missing += 1
+
+        count_interp = np.sum(find_missing) - count_missing
+
+        count = 0
+        for i in range(grid_shape[0]):
+            for j in range(grid_shape[1]):
+                new_flux[i, j, :] = test[count, :]
+                count += 1
+
+    elif len(parameters) == 3:
+        find_missing = np.zeros(grid_shape, dtype=bool)
+
+        values = []
+        points = [[], [], []]
+        new_points = [[], [], []]
+
+        new_flux = np.zeros((grid_shape[0], grid_shape[1], grid_shape[2],  wavelength.shape[0]))
+
+        for i in range(grid_shape[0]):
+            for j in range(grid_shape[1]):
+                for k in range(grid_shape[2]):
+                    if np.count_nonzero(flux[i, j, k, ...]) == 0:
+                        find_missing[i, j, k] = True
+
+                    else:
+                        points[0].append(param_data[0][i])
+                        points[1].append(param_data[1][j])
+                        points[2].append(param_data[2][k])
+
+                        values.append(flux[i, j, k, ...])
+
+                    new_points[0].append(param_data[0][i])
+                    new_points[1].append(param_data[1][j])
+                    new_points[2].append(param_data[2][k])
+
+                    count_total += 1
+
+        values = np.asarray(values)
+        points = np.asarray(points)
+        new_points = np.asarray(new_points)
+
+        test = griddata(points.T, values, new_points.T, method='linear')
+
+        for item in test:
+            if np.isnan(item[0]):
+                count_missing += 1
+
+        count_interp = np.sum(find_missing) - count_missing
+
+        count = 0
+        for i in range(grid_shape[0]):
+            for j in range(grid_shape[1]):
+                for k in range(grid_shape[2]):
+                    new_flux[i, j, k, :] = test[count, :]
+                    count += 1
+
+    elif len(parameters) == 4:
         find_missing = np.zeros(grid_shape, dtype=bool)
 
         values = []
         points = [[], [], [], []]
-        new_points = [[], [], [], []]        
+        new_points = [[], [], [], []]
 
         new_flux = np.zeros((grid_shape[0], grid_shape[1], grid_shape[2], grid_shape[3], wavelength.shape[0]))
 
@@ -304,6 +396,65 @@ def add_missing(model,
                     for m in range(grid_shape[3]):
                         new_flux[i, j, k, m, :] = test[count, :]
                         count += 1
+
+    elif len(parameters) == 5:
+        find_missing = np.zeros(grid_shape, dtype=bool)
+
+        values = []
+        points = [[], [], [], [], []]
+        new_points = [[], [], [], [], []]
+
+        new_flux = np.zeros((grid_shape[0], grid_shape[1], grid_shape[2], grid_shape[3], grid_shape[4], wavelength.shape[0]))
+
+        for i in range(grid_shape[0]):
+            for j in range(grid_shape[1]):
+                for k in range(grid_shape[2]):
+                    for m in range(grid_shape[3]):
+                        for n in range(grid_shape[4]):
+                            if np.count_nonzero(flux[i, j, k, m, n, ...]) == 0:
+                                find_missing[i, j, k, m, n] = True
+
+                            else:
+                                points[0].append(param_data[0][i])
+                                points[1].append(param_data[1][j])
+                                points[2].append(param_data[2][k])
+                                points[3].append(param_data[3][m])
+                                points[4].append(param_data[4][n])
+
+                                values.append(flux[i, j, k, m, n, ...])
+
+                            new_points[0].append(param_data[0][i])
+                            new_points[1].append(param_data[1][j])
+                            new_points[2].append(param_data[2][k])
+                            new_points[3].append(param_data[3][m])
+                            new_points[4].append(param_data[4][n])
+
+                            count_total += 1
+
+        values = np.asarray(values)
+        points = np.asarray(points)
+        new_points = np.asarray(new_points)
+
+        test = griddata(points.T, values, new_points.T, method='linear')
+
+        for item in test:
+            if np.isnan(item[0]):
+                count_missing += 1
+
+        count_interp = np.sum(find_missing) - count_missing
+
+        count = 0
+        for i in range(grid_shape[0]):
+            for j in range(grid_shape[1]):
+                for k in range(grid_shape[2]):
+                    for m in range(grid_shape[3]):
+                        for n in range(grid_shape[4]):
+                            new_flux[i, j, k, m, n, :] = test[count, :]
+                            count += 1
+
+    else:
+        raise ValueError('The add_missing function is currently not compatible with more than 5 '
+                         'parameters.')
 
     # if len(parameters) == 4:
     #     check_constant = np.zeros(grid_shape, dtype=bool)

--- a/species/util/phot_util.py
+++ b/species/util/phot_util.py
@@ -208,9 +208,7 @@ def get_residuals(datatype,
 
                 model = readmodel.get_spectrum(model_param=parameters, spec_res=1000.)
 
-                flux_new = spectres.spectres(new_spec_wavs=wl_new,
-                                             old_spec_wavs=model.wavelength,
-                                             spec_fluxes=model.flux)
+                flux_new = spectres.spectres(wl_new, model.wavelength, model.flux)
 
             else:
                 if spectrum == 'petitradtrans':
@@ -226,9 +224,7 @@ def get_residuals(datatype,
                     #
                     # # separate resampling to the new wavelength points
                     #
-                    # flux_new = spectres.spectres(new_spec_wavs=wl_new,
-                    #                              old_spec_wavs=model.wavelength,
-                    #                              spec_fluxes=model.flux)
+                    # flux_new = spectres.spectres(wl_new, model.wavelength, model.flux)
 
                 else:
                     readmodel = read_model.ReadModel(spectrum, wavel_range=wavel_range)

--- a/species/util/read_util.py
+++ b/species/util/read_util.py
@@ -113,7 +113,7 @@ def update_spectra(objectbox,
 
             print(f'Scaling the flux of {key}: {scaling:.2f}...', end='', flush=True)
             spec_tmp[:, 1] *= model_param[f'scaling_{key}']
-            spec_tmp[:, 2] *= model_param[f'scaling_{key}']
+            # spec_tmp[:, 2] *= model_param[f'scaling_{key}']
             print(' [DONE]')
 
         if f'error_{key}' in model_param:

--- a/test/test_read/test_calibration.py
+++ b/test/test_read/test_calibration.py
@@ -42,17 +42,8 @@ class TestCalibration:
         read_calib = species.ReadCalibration('vega', filter_name='Paranal/NACO.Lp')
         spec_box = read_calib.get_spectrum(self.model_param, apply_mask=True, spec_res=100.)
 
-        assert np.sum(spec_box.wavelength) == pytest.approx(79.79662545707652, rel=self.limit, abs=0.)
-        assert np.sum(spec_box.flux) == pytest.approx(1.094246808910988e-09, rel=self.limit, abs=0.)
-
-        with pytest.warns(UserWarning) as warning:
-            spec_box = read_calib.get_spectrum(self.model_param, apply_mask=True, spec_res=1000.,
-                                               extrapolate=True, min_wavelength=None)
-
-        assert len(warning) == 2
-
-        assert np.sum(spec_box.wavelength) == pytest.approx(2594.7730845698397, rel=self.limit, abs=0.)
-        assert np.sum(spec_box.flux) == pytest.approx(1.5194443166871866e-08, rel=self.limit, abs=0.)
+        assert np.sum(spec_box.wavelength) == pytest.approx(175.34279961519331, rel=self.limit, abs=0.)
+        assert np.sum(spec_box.flux) == pytest.approx(2.3081127325020912e-09, rel=self.limit, abs=0.)
 
     def test_get_flux(self):
         read_calib = species.ReadCalibration('vega', filter_name='Paranal/NACO.H')

--- a/test/test_read/test_isochrone.py
+++ b/test/test_read/test_isochrone.py
@@ -80,10 +80,10 @@ class TestIsochrone:
         assert colormag_box.color.shape == (10, )
         assert colormag_box.magnitude.shape == (10, )
 
-        assert np.sum(colormag_box.color) == pytest.approx(2.505139868830195,
+        assert np.sum(colormag_box.color) == pytest.approx(2.483071377517346,
                                                            rel=self.limit, abs=0.)
 
-        assert np.sum(colormag_box.magnitude) == pytest.approx(109.60059576762777,
+        assert np.sum(colormag_box.magnitude) == pytest.approx(109.57418536215742,
                                                                rel=self.limit, abs=0.)
 
         assert np.sum(colormag_box.sptype)  == pytest.approx(400., rel=self.limit, abs=0.)
@@ -101,10 +101,10 @@ class TestIsochrone:
         assert colorcolor_box.color1.shape == (10, )
         assert colorcolor_box.color2.shape == (10, )
 
-        assert np.sum(colorcolor_box.color1) == pytest.approx(2.505139868830195,
+        assert np.sum(colorcolor_box.color1) == pytest.approx(2.483071377517346,
                                                               rel=self.limit, abs=0.)
 
-        assert np.sum(colorcolor_box.color2) == pytest.approx(3.354962134446886,
+        assert np.sum(colorcolor_box.color2) == pytest.approx(3.3474795384424585,
                                                               rel=self.limit, abs=0.)
 
         assert np.sum(colorcolor_box.sptype) == pytest.approx(400., rel=self.limit, abs=0.)

--- a/test/test_read/test_model.py
+++ b/test/test_read/test_model.py
@@ -43,36 +43,36 @@ class TestModel:
                                          magnitude=False,
                                          smooth=True)
 
-        assert np.sum(model_box.wavelength) == pytest.approx(39.36850660634572, rel=self.limit, abs=0.)
-        assert np.sum(model_box.flux) == pytest.approx(7.549674442955264e-13, rel=self.limit, abs=0.)
+        assert np.sum(model_box.wavelength) == pytest.approx(82.34125130167924, rel=self.limit, abs=0.)
+        assert np.sum(model_box.flux) == pytest.approx(1.5427506511556731e-12, rel=self.limit, abs=0.)
 
         model_box = read_model.get_model(self.model_param,
                                          spec_res=100.,
                                          magnitude=True,
                                          smooth=True)
 
-        assert np.sum(model_box.wavelength) == pytest.approx(39.36850660634572, rel=self.limit, abs=0.)
-        assert np.sum(model_box.flux) == pytest.approx(275.6061491339208, rel=self.limit, abs=0.)
+        assert np.sum(model_box.wavelength) == pytest.approx(82.34125130167924, rel=self.limit, abs=0.)
+        assert np.sum(model_box.flux) == pytest.approx(576.6670455683387, rel=self.limit, abs=0.)
 
     def test_get_data(self):
         read_model = species.ReadModel('ames-cond', filter_name='Paranal/NACO.H')
         model_box = read_model.get_data(self.model_param)
 
-        assert np.sum(model_box.wavelength) == pytest.approx(47.859770458276856, rel=self.limit, abs=0.)
-        assert np.sum(model_box.flux) == pytest.approx(8.275363683007199e-13, rel=self.limit, abs=0.)
+        assert np.sum(model_box.wavelength) == pytest.approx(90.85089938365051, rel=self.limit, abs=0.)
+        assert np.sum(model_box.flux) == pytest.approx(1.6100966071681859e-12, rel=self.limit, abs=0.)
 
     def test_get_flux(self):
         read_model = species.ReadModel('ames-cond', filter_name='Paranal/NACO.H')
         flux = read_model.get_flux(self.model_param)
 
-        assert flux[0] == pytest.approx(3.3368963026400554e-14, rel=self.limit, abs=0.)
+        assert flux[0] == pytest.approx(3.3369304657212616e-14, rel=self.limit, abs=0.)
 
     def test_get_magnitude(self):
         read_model = species.ReadModel('ames-cond', filter_name='Paranal/NACO.H')
         magnitude = read_model.get_magnitude(self.model_param)
 
-        assert magnitude[0] == pytest.approx(11.357124426046317, rel=self.limit, abs=0.)
-        assert magnitude[1] == pytest.approx(11.357124426046317, rel=self.limit, abs=0.)
+        assert magnitude[0] == pytest.approx(11.357113310356498, rel=self.limit, abs=0.)
+        assert magnitude[1] == pytest.approx(11.357113310356498, rel=self.limit, abs=0.)
 
     def test_get_bounds(self):
         read_model = species.ReadModel('ames-cond', filter_name='Paranal/NACO.H')
@@ -85,7 +85,7 @@ class TestModel:
         read_model = species.ReadModel('ames-cond', filter_name='Paranal/NACO.H')
         wavelengths = read_model.get_wavelengths()
 
-        assert np.sum(wavelengths) == pytest.approx(401.2594, rel=1e-7, abs=0.)
+        assert np.sum(wavelengths) == pytest.approx(801.5391789533717, rel=1e-7, abs=0.)
 
     def test_get_points(self):
         read_model = species.ReadModel('ames-cond', filter_name='Paranal/NACO.H')

--- a/test/test_read/test_planck.py
+++ b/test/test_read/test_planck.py
@@ -35,18 +35,18 @@ class TestPlanck:
         modelbox = read_planck.get_spectrum({'teff': 2000., 'radius': 1., 'distance': 10.}, 100.)
 
         assert modelbox.model == 'planck'
-        assert modelbox.wavelength.shape == (22, )
-        assert modelbox.flux.shape == (22, )
+        assert modelbox.wavelength.shape == (42, )
+        assert modelbox.flux.shape == (42, )
 
-        assert np.sum(modelbox.wavelength) == pytest.approx(27.672469420634147, rel=self.limit, abs=0.)
-        assert np.sum(modelbox.flux) == pytest.approx(4.368588209687883e-13, rel=self.limit, abs=0.)
+        assert np.sum(modelbox.wavelength) == pytest.approx(52.7026751397061, rel=self.limit, abs=0.)
+        assert np.sum(modelbox.flux) == pytest.approx(8.332973825446955e-13, rel=self.limit, abs=0.)
 
     def test_get_flux(self):
         read_planck = species.ReadPlanck(filter_name='MKO/NSFCam.J')
 
         flux = read_planck.get_flux({'teff': 2000., 'radius': 1., 'distance': 10.})
-        assert flux[0] == pytest.approx(1.9896062423928137e-14, rel=self.limit, abs=0.)
+        assert flux[0] == pytest.approx(1.9888949873704357e-14, rel=self.limit, abs=0.)
 
         synphot = species.SyntheticPhotometry(filter_name='MKO/NSFCam.J')
         flux = read_planck.get_flux({'teff': 2000., 'radius': 1., 'distance': 10.}, synphot=synphot)
-        assert flux[0] == pytest.approx(1.9896062423928137e-14, rel=self.limit, abs=0.)
+        assert flux[0] == pytest.approx(1.9888949873704357e-14, rel=self.limit, abs=0.)


### PR DESCRIPTION
- Updated dependencies in `requirements.txt`.
- Added the `run_multinest` function in `FitModel` to use the nested sampling implementation of `MultiNest` for the parameter estimation. This can be in particular useful to sample multimodal distributions.
- Some changes in `add_samples` to make it compatible with both the MCMC and nested sampling results.
- Added errors in case the burnin of the MCMC samples is larger than the number of steps.
- Changed the group name of the fit results from `results/mcmc` to `results/fit`.
- Improved compatibility with the Exo-REM models, which are now resampled to a constant resolution of 1000 and available here:
https://people.phys.ethz.ch/~ipa/tstolker/exorem.tgz
Note that there is an issue with this set of spectra above ~1600 K because not all models properly converged.
- The luminosity is added to a `ModelBox` if the Teff and radius are available.
- Refactoring of `sort_data` to reduce its complexity.
- Improvement with the interpolation of missing grid points in `write_data` when the model spectra are stored in the database. Previously, the missing spectra were interpolated from neighboring Teff points but this is now done with a linear, multidimensional interpolation with `griddata` from `scipy`.