### PR TITLE
Bug fix building of the autodocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,4 +9,5 @@ build:
 python:
    version: 3.7
    install:
+      - requirements: requirements.txt
       - requirements: docs/requirements.txt

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,5 +9,4 @@ build:
 python:
    version: 3.7
    install:
-      - requirements: requirements.txt
       - requirements: docs/requirements.txt

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,7 +17,6 @@ import sys
 
 sys.path.insert(0, os.path.abspath('../'))
 
-
 # -- Project information -----------------------------------------------------
 
 project = 'species'
@@ -29,10 +28,6 @@ with open('../species/__init__.py') as initfile:
     for line in initfile:
         if '__version__' in line:
             version = line.split("'")[1]
-
-# The full version, including alpha/beta/rc tags
-release = version
-
 
 # -- General configuration ---------------------------------------------------
 
@@ -176,7 +171,7 @@ man_pages = [
 #  dir menu entry, description, category)
 texinfo_documents = [
     (master_doc, 'species', 'species Documentation',
-     author, 'species', 'Toolkit for spectral and photometric analysis of planetary and substellar atmospheres',
+     author, 'species', 'Toolkit for atmospheric characterization of exoplanets and brown dwarf',
      'Miscellaneous'),
 ]
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,6 @@
-nbsphinx
-pandoc
-jupyter
-emcee
-h5py
+nbsphinx ~= 0.6
+pandoc ~= 1.0
+jupyter ~= 1.0
+emcee ~= 3.0
+h5py ~= 2.10
+tqdm ~= 4.45

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,3 +2,4 @@ nbsphinx
 pandoc
 jupyter
 emcee
+h5py

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,16 @@
 nbsphinx ~= 0.6
 pandoc ~= 1.0
 jupyter ~= 1.0
+
+astropy ~= 4.0
+astroquery ~= 0.4
+corner ~= 2.0
 emcee ~= 3.0
 h5py ~= 2.10
+matplotlib ~= 3.2
+numpy ~= 1.18
+pandas ~= 0.25
+scipy ~= 1.4
+spectres ~= 2.1
 tqdm ~= 4.45
+xlrd ~= 1.2

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,16 +1,3 @@
 nbsphinx ~= 0.6
 pandoc ~= 1.0
 jupyter ~= 1.0
-
-astropy ~= 4.0
-astroquery ~= 0.4
-corner ~= 2.0
-emcee ~= 3.0
-h5py ~= 2.10
-matplotlib ~= 3.2
-numpy ~= 1.18
-pandas ~= 0.25
-scipy ~= 1.4
-spectres ~= 2.1
-tqdm ~= 4.45
-xlrd ~= 1.2

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
 nbsphinx
 pandoc
 jupyter
+emcee

--- a/docs/tutorials/synthetic_photometry.ipynb
+++ b/docs/tutorials/synthetic_photometry.ipynb
@@ -296,7 +296,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.0"
+   "version": "3.6.10"
   }
  },
  "nbformat": 4,

--- a/species/analysis/fit_model.py
+++ b/species/analysis/fit_model.py
@@ -14,7 +14,7 @@ import numpy as np
 try:
     import pymultinest
 except:
-    pass
+    warnings.warn('PyMultiNest could not be imported.')
 
 from species.core import constants
 from species.data import database

--- a/species/analysis/fit_model.py
+++ b/species/analysis/fit_model.py
@@ -9,7 +9,7 @@ import warnings
 from multiprocessing import Pool, cpu_count
 
 import emcee
-import pymultinest
+# import pymultinest
 import numpy as np
 
 from species.core import constants
@@ -435,188 +435,188 @@ class FitModel:
                                distance=self.distance[0],
                                spec_labels=spec_labels)
 
-    def run_multinest(self,
-                      tag,
-                      n_live_points=4000,
-                      output='multinest/'):
-        """
-        Function to run the ``PyMultiNest`` wrapper of the ``MultiNest`` sampler. While
-        ``PyMultiNest`` can be installed with ``pip`` from the PyPI repository, ``MultiNest``
-        has to to be build manually. See the ``PyMultiNest`` documentation for details:
-        http://johannesbuchner.github.io/PyMultiNest/install.html. Note that the library path
-        of ``MultiNest`` should be set to the environmental variable ``LD_LIBRARY_PATH`` on a
-        Linux machine and ``DYLD_LIBRARY_PATH`` on a Mac. Alternatively, the variable can be
-        set before importing the ``species`` package, for example:
-
-        .. code-block:: python
-
-            >>> import os
-            >>> os.environ['DYLD_LIBRARY_PATH'] = '/path/to/MultiNest/lib'
-            >>> import species
-
-        Parameters
-        ----------
-        tag : str
-            Database tag where the samples will be stored.
-        n_live_points : int
-            Number of live points.
-        output : str
-            Path that is used for the output files from MultiNest.
-
-        Returns
-        -------
-        NoneType
-            None
-        """
-
-        print('Running nested sampling...')
-
-        # create the output folder if required
-
-        if not os.path.exists(output):
-            os.mkdir(output)
-
-        # create a dictionary with the cube indices of the parameters
-
-        cube_index = {}
-        for i, item in enumerate(self.modelpar):
-            cube_index[item] = i
-
-        def lnprior_multinest(cube, n_dim, n_param):
-            """
-            Function to transform the unit cube into the parameter cube. It is not clear how to
-            pass additional arguments to the function, therefore it is placed here.
-
-            Parameters
-            ----------
-            cube : pymultinest.run.LP_c_double
-                Unit cube.
-
-            Returns
-            -------
-            NoneType
-                None
-            """
-
-            # Effective temperature (K)
-            cube[cube_index['teff']] = self.bounds['teff'][0] + \
-                (self.bounds['teff'][1]-self.bounds['teff'][0])*cube[cube_index['teff']]
-
-            # Surface gravity (dex)
-            cube[cube_index['logg']] = self.bounds['logg'][0] + \
-                (self.bounds['logg'][1]-self.bounds['logg'][0])*cube[cube_index['logg']]
-
-            # Radius (Rjup)
-            cube[cube_index['radius']] = self.bounds['radius'][0] + \
-                (self.bounds['radius'][1]-self.bounds['radius'][0])*cube[cube_index['radius']]
-
-            # Metallicity [Fe/H]
-            if 'feh' in self.bounds:
-                cube[cube_index['feh']] = self.bounds['feh'][0] + \
-                    (self.bounds['feh'][1]-self.bounds['feh'][0])*cube[cube_index['feh']]
-
-            # C/O ratio
-            if 'co' in self.bounds:
-                cube[cube_index['co']] = self.bounds['co'][0] + \
-                    (self.bounds['co'][1]-self.bounds['co'][0])*cube[cube_index['co']]
-
-            # Sedimentation parameter
-            if 'fsed' in self.bounds:
-
-                cube[cube_index['fsed']] = self.bounds['fsed'][0] + \
-                    (self.bounds['fsed'][1]-self.bounds['fsed'][0])*cube[cube_index['fsed']]
-
-            # Spectrum scaling
-            if self.spectrum is not None:
-                for item in self.spectrum:
-                    if f'scaling_{item}' in self.bounds:
-                        cube[cube_index[f'scaling_{item}']] = self.bounds[f'scaling_{item}'][0] + \
-                            (self.bounds[f'scaling_{item}'][1]-self.bounds[f'scaling_{item}'][0]) \
-                            * cube[cube_index[f'scaling_{item}']]
-
-        def lnlike_multinest(cube, n_dim, n_param):
-            """
-            Function for the logarithm of the likelihood, computed from the parameter cube.
-
-            Parameters
-            ----------
-            cube : pymultinest.run.LP_c_double
-                Unit cube.
-
-            Returns
-            -------
-            float
-                The logarithm of the likelihood.
-            """
-
-            paramdict = {}
-            spec_scaling = {}
-
-            for i, item in enumerate(self.modelpar):
-                if item == 'radius':
-                    radius = cube[cube_index['radius']]
-
-                elif item[:8] == 'scaling_' and item[8:] in self.spectrum:
-                    spec_scaling[item[8:]] = cube[cube_index[item]]
-
-                else:
-                    paramdict[item] = cube[cube_index[item]]
-
-            scaling = (radius*constants.R_JUP)**2 / (self.distance[0]*constants.PARSEC)**2
-
-            chisq = 0.
-
-            if self.objphot is not None:
-                for i, item in enumerate(self.objphot):
-                    flux = scaling * self.modelphot[i].spectrum_interp(list(paramdict.values()))
-                    chisq += (item[0]-flux)**2 / item[1]**2
-
-            if self.spectrum is not None:
-                for i, item in enumerate(self.spectrum.keys()):
-
-                    flux = scaling * self.modelspec[i].spectrum_interp(list(paramdict.values()))[0, :]
-
-                    if item in spec_scaling:
-                        flux_obs = spec_scaling[item]*self.spectrum[item][0][:, 1]
-                    else:
-                        flux_obs = self.spectrum[item][0][:, 1]
-
-                    if self.spectrum[item][2] is not None:
-                        spec_diff = flux_obs - flux
-                        chisq += np.dot(spec_diff, np.dot(self.spectrum[item][2], spec_diff))
-
-                    else:
-                        chisq += np.nansum((flux_obs-flux)**2 / self.spectrum[item][0][:, 2]**2)
-
-            return -0.5*chisq
-
-        pymultinest.run(lnlike_multinest,
-                        lnprior_multinest,
-                        len(self.modelpar),
-                        outputfiles_basename=output,
-                        resume=False,
-                        n_live_points=n_live_points)
-
-        samples = np.loadtxt(f'{output}/post_equal_weights.dat')
-
-        species_db = database.Database()
-
-        spec_labels = []
-
-        if self.spectrum is not None:
-            for item in self.spectrum:
-                if f'scaling_{item}' in self.bounds:
-                    spec_labels.append(f'scaling_{item}')
-
-        else:
-            spec_labels = None
-
-        species_db.add_samples(sampler='multinest',
-                               samples=samples[:, :-1],
-                               ln_prob=samples[:, -1],
-                               mean_accept=None,
-                               spectrum=('model', self.model),
-                               tag=tag,
-                               modelpar=self.modelpar,
-                               distance=self.distance[0],
-                               spec_labels=spec_labels)
+    # def run_multinest(self,
+    #                   tag,
+    #                   n_live_points=4000,
+    #                   output='multinest/'):
+    #     """
+    #     Function to run the ``PyMultiNest`` wrapper of the ``MultiNest`` sampler. While
+    #     ``PyMultiNest`` can be installed with ``pip`` from the PyPI repository, ``MultiNest``
+    #     has to to be build manually. See the ``PyMultiNest`` documentation for details:
+    #     http://johannesbuchner.github.io/PyMultiNest/install.html. Note that the library path
+    #     of ``MultiNest`` should be set to the environmental variable ``LD_LIBRARY_PATH`` on a
+    #     Linux machine and ``DYLD_LIBRARY_PATH`` on a Mac. Alternatively, the variable can be
+    #     set before importing the ``species`` package, for example:
+    #
+    #     .. code-block:: python
+    #
+    #         >>> import os
+    #         >>> os.environ['DYLD_LIBRARY_PATH'] = '/path/to/MultiNest/lib'
+    #         >>> import species
+    #
+    #     Parameters
+    #     ----------
+    #     tag : str
+    #         Database tag where the samples will be stored.
+    #     n_live_points : int
+    #         Number of live points.
+    #     output : str
+    #         Path that is used for the output files from MultiNest.
+    #
+    #     Returns
+    #     -------
+    #     NoneType
+    #         None
+    #     """
+    #
+    #     print('Running nested sampling...')
+    #
+    #     # create the output folder if required
+    #
+    #     if not os.path.exists(output):
+    #         os.mkdir(output)
+    #
+    #     # create a dictionary with the cube indices of the parameters
+    #
+    #     cube_index = {}
+    #     for i, item in enumerate(self.modelpar):
+    #         cube_index[item] = i
+    #
+    #     def lnprior_multinest(cube, n_dim, n_param):
+    #         """
+    #         Function to transform the unit cube into the parameter cube. It is not clear how to
+    #         pass additional arguments to the function, therefore it is placed here.
+    #
+    #         Parameters
+    #         ----------
+    #         cube : pymultinest.run.LP_c_double
+    #             Unit cube.
+    #
+    #         Returns
+    #         -------
+    #         NoneType
+    #             None
+    #         """
+    #
+    #         # Effective temperature (K)
+    #         cube[cube_index['teff']] = self.bounds['teff'][0] + \
+    #             (self.bounds['teff'][1]-self.bounds['teff'][0])*cube[cube_index['teff']]
+    #
+    #         # Surface gravity (dex)
+    #         cube[cube_index['logg']] = self.bounds['logg'][0] + \
+    #             (self.bounds['logg'][1]-self.bounds['logg'][0])*cube[cube_index['logg']]
+    #
+    #         # Radius (Rjup)
+    #         cube[cube_index['radius']] = self.bounds['radius'][0] + \
+    #             (self.bounds['radius'][1]-self.bounds['radius'][0])*cube[cube_index['radius']]
+    #
+    #         # Metallicity [Fe/H]
+    #         if 'feh' in self.bounds:
+    #             cube[cube_index['feh']] = self.bounds['feh'][0] + \
+    #                 (self.bounds['feh'][1]-self.bounds['feh'][0])*cube[cube_index['feh']]
+    #
+    #         # C/O ratio
+    #         if 'co' in self.bounds:
+    #             cube[cube_index['co']] = self.bounds['co'][0] + \
+    #                 (self.bounds['co'][1]-self.bounds['co'][0])*cube[cube_index['co']]
+    #
+    #         # Sedimentation parameter
+    #         if 'fsed' in self.bounds:
+    #
+    #             cube[cube_index['fsed']] = self.bounds['fsed'][0] + \
+    #                 (self.bounds['fsed'][1]-self.bounds['fsed'][0])*cube[cube_index['fsed']]
+    #
+    #         # Spectrum scaling
+    #         if self.spectrum is not None:
+    #             for item in self.spectrum:
+    #                 if f'scaling_{item}' in self.bounds:
+    #                     cube[cube_index[f'scaling_{item}']] = self.bounds[f'scaling_{item}'][0] + \
+    #                         (self.bounds[f'scaling_{item}'][1]-self.bounds[f'scaling_{item}'][0]) \
+    #                         * cube[cube_index[f'scaling_{item}']]
+    #
+    #     def lnlike_multinest(cube, n_dim, n_param):
+    #         """
+    #         Function for the logarithm of the likelihood, computed from the parameter cube.
+    #
+    #         Parameters
+    #         ----------
+    #         cube : pymultinest.run.LP_c_double
+    #             Unit cube.
+    #
+    #         Returns
+    #         -------
+    #         float
+    #             The logarithm of the likelihood.
+    #         """
+    #
+    #         paramdict = {}
+    #         spec_scaling = {}
+    #
+    #         for i, item in enumerate(self.modelpar):
+    #             if item == 'radius':
+    #                 radius = cube[cube_index['radius']]
+    #
+    #             elif item[:8] == 'scaling_' and item[8:] in self.spectrum:
+    #                 spec_scaling[item[8:]] = cube[cube_index[item]]
+    #
+    #             else:
+    #                 paramdict[item] = cube[cube_index[item]]
+    #
+    #         scaling = (radius*constants.R_JUP)**2 / (self.distance[0]*constants.PARSEC)**2
+    #
+    #         chisq = 0.
+    #
+    #         if self.objphot is not None:
+    #             for i, item in enumerate(self.objphot):
+    #                 flux = scaling * self.modelphot[i].spectrum_interp(list(paramdict.values()))
+    #                 chisq += (item[0]-flux)**2 / item[1]**2
+    #
+    #         if self.spectrum is not None:
+    #             for i, item in enumerate(self.spectrum.keys()):
+    #
+    #                 flux = scaling * self.modelspec[i].spectrum_interp(list(paramdict.values()))[0, :]
+    #
+    #                 if item in spec_scaling:
+    #                     flux_obs = spec_scaling[item]*self.spectrum[item][0][:, 1]
+    #                 else:
+    #                     flux_obs = self.spectrum[item][0][:, 1]
+    #
+    #                 if self.spectrum[item][2] is not None:
+    #                     spec_diff = flux_obs - flux
+    #                     chisq += np.dot(spec_diff, np.dot(self.spectrum[item][2], spec_diff))
+    #
+    #                 else:
+    #                     chisq += np.nansum((flux_obs-flux)**2 / self.spectrum[item][0][:, 2]**2)
+    #
+    #         return -0.5*chisq
+    #
+    #     pymultinest.run(lnlike_multinest,
+    #                     lnprior_multinest,
+    #                     len(self.modelpar),
+    #                     outputfiles_basename=output,
+    #                     resume=False,
+    #                     n_live_points=n_live_points)
+    #
+    #     samples = np.loadtxt(f'{output}/post_equal_weights.dat')
+    #
+    #     species_db = database.Database()
+    #
+    #     spec_labels = []
+    #
+    #     if self.spectrum is not None:
+    #         for item in self.spectrum:
+    #             if f'scaling_{item}' in self.bounds:
+    #                 spec_labels.append(f'scaling_{item}')
+    #
+    #     else:
+    #         spec_labels = None
+    #
+    #     species_db.add_samples(sampler='multinest',
+    #                            samples=samples[:, :-1],
+    #                            ln_prob=samples[:, -1],
+    #                            mean_accept=None,
+    #                            spectrum=('model', self.model),
+    #                            tag=tag,
+    #                            modelpar=self.modelpar,
+    #                            distance=self.distance[0],
+    #                            spec_labels=spec_labels)

--- a/species/analysis/fit_model.py
+++ b/species/analysis/fit_model.py
@@ -9,8 +9,12 @@ import warnings
 from multiprocessing import Pool, cpu_count
 
 import emcee
-import pymultinest
 import numpy as np
+
+try:
+    import pymultinest
+except:
+    pass
 
 from species.core import constants
 from species.data import database

--- a/species/analysis/fit_model.py
+++ b/species/analysis/fit_model.py
@@ -9,7 +9,7 @@ import warnings
 from multiprocessing import Pool, cpu_count
 
 import emcee
-# import pymultinest
+import pymultinest
 import numpy as np
 
 from species.core import constants
@@ -435,188 +435,188 @@ class FitModel:
                                distance=self.distance[0],
                                spec_labels=spec_labels)
 
-    # def run_multinest(self,
-    #                   tag,
-    #                   n_live_points=4000,
-    #                   output='multinest/'):
-    #     """
-    #     Function to run the ``PyMultiNest`` wrapper of the ``MultiNest`` sampler. While
-    #     ``PyMultiNest`` can be installed with ``pip`` from the PyPI repository, ``MultiNest``
-    #     has to to be build manually. See the ``PyMultiNest`` documentation for details:
-    #     http://johannesbuchner.github.io/PyMultiNest/install.html. Note that the library path
-    #     of ``MultiNest`` should be set to the environmental variable ``LD_LIBRARY_PATH`` on a
-    #     Linux machine and ``DYLD_LIBRARY_PATH`` on a Mac. Alternatively, the variable can be
-    #     set before importing the ``species`` package, for example:
-    #
-    #     .. code-block:: python
-    #
-    #         >>> import os
-    #         >>> os.environ['DYLD_LIBRARY_PATH'] = '/path/to/MultiNest/lib'
-    #         >>> import species
-    #
-    #     Parameters
-    #     ----------
-    #     tag : str
-    #         Database tag where the samples will be stored.
-    #     n_live_points : int
-    #         Number of live points.
-    #     output : str
-    #         Path that is used for the output files from MultiNest.
-    #
-    #     Returns
-    #     -------
-    #     NoneType
-    #         None
-    #     """
-    #
-    #     print('Running nested sampling...')
-    #
-    #     # create the output folder if required
-    #
-    #     if not os.path.exists(output):
-    #         os.mkdir(output)
-    #
-    #     # create a dictionary with the cube indices of the parameters
-    #
-    #     cube_index = {}
-    #     for i, item in enumerate(self.modelpar):
-    #         cube_index[item] = i
-    #
-    #     def lnprior_multinest(cube, n_dim, n_param):
-    #         """
-    #         Function to transform the unit cube into the parameter cube. It is not clear how to
-    #         pass additional arguments to the function, therefore it is placed here.
-    #
-    #         Parameters
-    #         ----------
-    #         cube : pymultinest.run.LP_c_double
-    #             Unit cube.
-    #
-    #         Returns
-    #         -------
-    #         NoneType
-    #             None
-    #         """
-    #
-    #         # Effective temperature (K)
-    #         cube[cube_index['teff']] = self.bounds['teff'][0] + \
-    #             (self.bounds['teff'][1]-self.bounds['teff'][0])*cube[cube_index['teff']]
-    #
-    #         # Surface gravity (dex)
-    #         cube[cube_index['logg']] = self.bounds['logg'][0] + \
-    #             (self.bounds['logg'][1]-self.bounds['logg'][0])*cube[cube_index['logg']]
-    #
-    #         # Radius (Rjup)
-    #         cube[cube_index['radius']] = self.bounds['radius'][0] + \
-    #             (self.bounds['radius'][1]-self.bounds['radius'][0])*cube[cube_index['radius']]
-    #
-    #         # Metallicity [Fe/H]
-    #         if 'feh' in self.bounds:
-    #             cube[cube_index['feh']] = self.bounds['feh'][0] + \
-    #                 (self.bounds['feh'][1]-self.bounds['feh'][0])*cube[cube_index['feh']]
-    #
-    #         # C/O ratio
-    #         if 'co' in self.bounds:
-    #             cube[cube_index['co']] = self.bounds['co'][0] + \
-    #                 (self.bounds['co'][1]-self.bounds['co'][0])*cube[cube_index['co']]
-    #
-    #         # Sedimentation parameter
-    #         if 'fsed' in self.bounds:
-    #
-    #             cube[cube_index['fsed']] = self.bounds['fsed'][0] + \
-    #                 (self.bounds['fsed'][1]-self.bounds['fsed'][0])*cube[cube_index['fsed']]
-    #
-    #         # Spectrum scaling
-    #         if self.spectrum is not None:
-    #             for item in self.spectrum:
-    #                 if f'scaling_{item}' in self.bounds:
-    #                     cube[cube_index[f'scaling_{item}']] = self.bounds[f'scaling_{item}'][0] + \
-    #                         (self.bounds[f'scaling_{item}'][1]-self.bounds[f'scaling_{item}'][0]) \
-    #                         * cube[cube_index[f'scaling_{item}']]
-    #
-    #     def lnlike_multinest(cube, n_dim, n_param):
-    #         """
-    #         Function for the logarithm of the likelihood, computed from the parameter cube.
-    #
-    #         Parameters
-    #         ----------
-    #         cube : pymultinest.run.LP_c_double
-    #             Unit cube.
-    #
-    #         Returns
-    #         -------
-    #         float
-    #             The logarithm of the likelihood.
-    #         """
-    #
-    #         paramdict = {}
-    #         spec_scaling = {}
-    #
-    #         for i, item in enumerate(self.modelpar):
-    #             if item == 'radius':
-    #                 radius = cube[cube_index['radius']]
-    #
-    #             elif item[:8] == 'scaling_' and item[8:] in self.spectrum:
-    #                 spec_scaling[item[8:]] = cube[cube_index[item]]
-    #
-    #             else:
-    #                 paramdict[item] = cube[cube_index[item]]
-    #
-    #         scaling = (radius*constants.R_JUP)**2 / (self.distance[0]*constants.PARSEC)**2
-    #
-    #         chisq = 0.
-    #
-    #         if self.objphot is not None:
-    #             for i, item in enumerate(self.objphot):
-    #                 flux = scaling * self.modelphot[i].spectrum_interp(list(paramdict.values()))
-    #                 chisq += (item[0]-flux)**2 / item[1]**2
-    #
-    #         if self.spectrum is not None:
-    #             for i, item in enumerate(self.spectrum.keys()):
-    #
-    #                 flux = scaling * self.modelspec[i].spectrum_interp(list(paramdict.values()))[0, :]
-    #
-    #                 if item in spec_scaling:
-    #                     flux_obs = spec_scaling[item]*self.spectrum[item][0][:, 1]
-    #                 else:
-    #                     flux_obs = self.spectrum[item][0][:, 1]
-    #
-    #                 if self.spectrum[item][2] is not None:
-    #                     spec_diff = flux_obs - flux
-    #                     chisq += np.dot(spec_diff, np.dot(self.spectrum[item][2], spec_diff))
-    #
-    #                 else:
-    #                     chisq += np.nansum((flux_obs-flux)**2 / self.spectrum[item][0][:, 2]**2)
-    #
-    #         return -0.5*chisq
-    #
-    #     pymultinest.run(lnlike_multinest,
-    #                     lnprior_multinest,
-    #                     len(self.modelpar),
-    #                     outputfiles_basename=output,
-    #                     resume=False,
-    #                     n_live_points=n_live_points)
-    #
-    #     samples = np.loadtxt(f'{output}/post_equal_weights.dat')
-    #
-    #     species_db = database.Database()
-    #
-    #     spec_labels = []
-    #
-    #     if self.spectrum is not None:
-    #         for item in self.spectrum:
-    #             if f'scaling_{item}' in self.bounds:
-    #                 spec_labels.append(f'scaling_{item}')
-    #
-    #     else:
-    #         spec_labels = None
-    #
-    #     species_db.add_samples(sampler='multinest',
-    #                            samples=samples[:, :-1],
-    #                            ln_prob=samples[:, -1],
-    #                            mean_accept=None,
-    #                            spectrum=('model', self.model),
-    #                            tag=tag,
-    #                            modelpar=self.modelpar,
-    #                            distance=self.distance[0],
-    #                            spec_labels=spec_labels)
+    def run_multinest(self,
+                      tag,
+                      n_live_points=4000,
+                      output='multinest/'):
+        """
+        Function to run the ``PyMultiNest`` wrapper of the ``MultiNest`` sampler. While
+        ``PyMultiNest`` can be installed with ``pip`` from the PyPI repository, ``MultiNest``
+        has to to be build manually. See the ``PyMultiNest`` documentation for details:
+        http://johannesbuchner.github.io/PyMultiNest/install.html. Note that the library path
+        of ``MultiNest`` should be set to the environmental variable ``LD_LIBRARY_PATH`` on a
+        Linux machine and ``DYLD_LIBRARY_PATH`` on a Mac. Alternatively, the variable can be
+        set before importing the ``species`` package, for example:
+
+        .. code-block:: python
+
+            >>> import os
+            >>> os.environ['DYLD_LIBRARY_PATH'] = '/path/to/MultiNest/lib'
+            >>> import species
+
+        Parameters
+        ----------
+        tag : str
+            Database tag where the samples will be stored.
+        n_live_points : int
+            Number of live points.
+        output : str
+            Path that is used for the output files from MultiNest.
+
+        Returns
+        -------
+        NoneType
+            None
+        """
+
+        print('Running nested sampling...')
+
+        # create the output folder if required
+
+        if not os.path.exists(output):
+            os.mkdir(output)
+
+        # create a dictionary with the cube indices of the parameters
+
+        cube_index = {}
+        for i, item in enumerate(self.modelpar):
+            cube_index[item] = i
+
+        def lnprior_multinest(cube, n_dim, n_param):
+            """
+            Function to transform the unit cube into the parameter cube. It is not clear how to
+            pass additional arguments to the function, therefore it is placed here.
+
+            Parameters
+            ----------
+            cube : pymultinest.run.LP_c_double
+                Unit cube.
+
+            Returns
+            -------
+            NoneType
+                None
+            """
+
+            # Effective temperature (K)
+            cube[cube_index['teff']] = self.bounds['teff'][0] + \
+                (self.bounds['teff'][1]-self.bounds['teff'][0])*cube[cube_index['teff']]
+
+            # Surface gravity (dex)
+            cube[cube_index['logg']] = self.bounds['logg'][0] + \
+                (self.bounds['logg'][1]-self.bounds['logg'][0])*cube[cube_index['logg']]
+
+            # Radius (Rjup)
+            cube[cube_index['radius']] = self.bounds['radius'][0] + \
+                (self.bounds['radius'][1]-self.bounds['radius'][0])*cube[cube_index['radius']]
+
+            # Metallicity [Fe/H]
+            if 'feh' in self.bounds:
+                cube[cube_index['feh']] = self.bounds['feh'][0] + \
+                    (self.bounds['feh'][1]-self.bounds['feh'][0])*cube[cube_index['feh']]
+
+            # C/O ratio
+            if 'co' in self.bounds:
+                cube[cube_index['co']] = self.bounds['co'][0] + \
+                    (self.bounds['co'][1]-self.bounds['co'][0])*cube[cube_index['co']]
+
+            # Sedimentation parameter
+            if 'fsed' in self.bounds:
+
+                cube[cube_index['fsed']] = self.bounds['fsed'][0] + \
+                    (self.bounds['fsed'][1]-self.bounds['fsed'][0])*cube[cube_index['fsed']]
+
+            # Spectrum scaling
+            if self.spectrum is not None:
+                for item in self.spectrum:
+                    if f'scaling_{item}' in self.bounds:
+                        cube[cube_index[f'scaling_{item}']] = self.bounds[f'scaling_{item}'][0] + \
+                            (self.bounds[f'scaling_{item}'][1]-self.bounds[f'scaling_{item}'][0]) \
+                            * cube[cube_index[f'scaling_{item}']]
+
+        def lnlike_multinest(cube, n_dim, n_param):
+            """
+            Function for the logarithm of the likelihood, computed from the parameter cube.
+
+            Parameters
+            ----------
+            cube : pymultinest.run.LP_c_double
+                Unit cube.
+
+            Returns
+            -------
+            float
+                The logarithm of the likelihood.
+            """
+
+            paramdict = {}
+            spec_scaling = {}
+
+            for i, item in enumerate(self.modelpar):
+                if item == 'radius':
+                    radius = cube[cube_index['radius']]
+
+                elif item[:8] == 'scaling_' and item[8:] in self.spectrum:
+                    spec_scaling[item[8:]] = cube[cube_index[item]]
+
+                else:
+                    paramdict[item] = cube[cube_index[item]]
+
+            scaling = (radius*constants.R_JUP)**2 / (self.distance[0]*constants.PARSEC)**2
+
+            chisq = 0.
+
+            if self.objphot is not None:
+                for i, item in enumerate(self.objphot):
+                    flux = scaling * self.modelphot[i].spectrum_interp(list(paramdict.values()))
+                    chisq += (item[0]-flux)**2 / item[1]**2
+
+            if self.spectrum is not None:
+                for i, item in enumerate(self.spectrum.keys()):
+
+                    flux = scaling * self.modelspec[i].spectrum_interp(list(paramdict.values()))[0, :]
+
+                    if item in spec_scaling:
+                        flux_obs = spec_scaling[item]*self.spectrum[item][0][:, 1]
+                    else:
+                        flux_obs = self.spectrum[item][0][:, 1]
+
+                    if self.spectrum[item][2] is not None:
+                        spec_diff = flux_obs - flux
+                        chisq += np.dot(spec_diff, np.dot(self.spectrum[item][2], spec_diff))
+
+                    else:
+                        chisq += np.nansum((flux_obs-flux)**2 / self.spectrum[item][0][:, 2]**2)
+
+            return -0.5*chisq
+
+        pymultinest.run(lnlike_multinest,
+                        lnprior_multinest,
+                        len(self.modelpar),
+                        outputfiles_basename=output,
+                        resume=False,
+                        n_live_points=n_live_points)
+
+        samples = np.loadtxt(f'{output}/post_equal_weights.dat')
+
+        species_db = database.Database()
+
+        spec_labels = []
+
+        if self.spectrum is not None:
+            for item in self.spectrum:
+                if f'scaling_{item}' in self.bounds:
+                    spec_labels.append(f'scaling_{item}')
+
+        else:
+            spec_labels = None
+
+        species_db.add_samples(sampler='multinest',
+                               samples=samples[:, :-1],
+                               ln_prob=samples[:, -1],
+                               mean_accept=None,
+                               spectrum=('model', self.model),
+                               tag=tag,
+                               modelpar=self.modelpar,
+                               distance=self.distance[0],
+                               spec_labels=spec_labels)

--- a/species/data/vlm_plx.py
+++ b/species/data/vlm_plx.py
@@ -87,6 +87,8 @@ def add_vlm_plx(input_path,
 
     database.create_dataset('photometry/vlm-plx/ra', data=phot_data['RA'])  # (deg)
     database.create_dataset('photometry/vlm-plx/dec', data=phot_data['DEC'])  # (deg)
+    database.create_dataset('photometry/vlm-plx/parallax', data=parallax)
+    database.create_dataset('photometry/vlm-plx/parallax_error', data=parallax_error)
     database.create_dataset('photometry/vlm-plx/distance', data=distance)
     database.create_dataset('photometry/vlm-plx/distance_error', data=distance_error)
     database.create_dataset('photometry/vlm-plx/MKO/NSFCam.Y', data=phot_data['YMAG'])


### PR DESCRIPTION
The autodocs were not building due to the external Fortran library (`MultiNest`, which can not be installed on `readthedocs`) that is required by `PyMultiNest`. This was solved by adding a `try ... except` at the import of `PyMultiNest`. So the API documentation should be available again!

https://species.readthedocs.io/en/latest/modules.html