### PR TITLE
Nested sampling with FitPlanck

### DIFF
--- a/species/analysis/fit_model.py
+++ b/species/analysis/fit_model.py
@@ -11,7 +11,7 @@ from multiprocessing import Pool, cpu_count
 import emcee
 import numpy as np
 
-# installation of MultiNest is not possible on readthedocs 
+# installation of MultiNest is not possible on readthedocs
 try:
     import pymultinest
 except:
@@ -63,7 +63,7 @@ def lnprior(param,
 
             if prior is not None and prior[0] == 'mass' and item == 'logg':
                 mass = read_util.get_mass(modeldict)
-                ln_prior += -0.5*(mass-prior[1])**2/prior[2]**2
+                ln_prior += -0.5*(mass - prior[1])**2 / prior[2]**2
 
             else:
                 ln_prior += 0.
@@ -135,8 +135,8 @@ def lnlike(param,
                 chisq += (obj_item[0] - flux)**2 / obj_item[1]**2
 
             else:
-                for i in range(obj_item.shape[1]):
-                    chisq += (obj_item[0, i] - flux)**2 / obj_item[1, i]**2
+                for j in range(obj_item.shape[1]):
+                    chisq += (obj_item[0, j] - flux)**2 / obj_item[1, j]**2
 
     if spectrum is not None:
         for i, item in enumerate(spectrum.keys()):
@@ -585,8 +585,8 @@ class FitModel:
                         chisq += (obj_item[0] - flux)**2 / obj_item[1]**2
 
                     else:
-                        for i in range(obj_item.shape[1]):
-                            chisq += (obj_item[0, i] - flux)**2 / obj_item[1, i]**2
+                        for j in range(obj_item.shape[1]):
+                            chisq += (obj_item[0, j] - flux)**2 / obj_item[1, j]**2
 
             if self.spectrum is not None:
                 for i, item in enumerate(self.spectrum.keys()):

--- a/species/analysis/fit_spectrum.py
+++ b/species/analysis/fit_spectrum.py
@@ -61,8 +61,8 @@ def lnprob(param,
                 chisq += (obj_item[0] - param[0]*specphot[i])**2 / obj_item[1]**2
 
             else:
-                for i in range(obj_item.shape[1]):
-                    chisq += (obj_item[0, i] - param[0]*specphot[i])**2 / obj_item[1, i]**2
+                for j in range(obj_item.shape[1]):
+                    chisq += (obj_item[0, j] - param[0]*specphot[i])**2 / obj_item[1, j]**2
 
         ln_prob = ln_prior - 0.5*chisq
 

--- a/species/data/companions.py
+++ b/species/data/companions.py
@@ -104,9 +104,9 @@ def get_data():
                                      'Paranal/SPHERE.IRDIS_D_H23_3': (17.95, 0.17),  # Keppler et al. 2018
                                      'Paranal/SPHERE.IRDIS_D_K12_1': [(16.78, 0.31), (16.72, 0.05)],  # Stolker et al. in prep.
                                      'Paranal/SPHERE.IRDIS_D_K12_2': [(16.23, 0.32), (16.38, 0.06)], # Stolker et al. in prep.
-                                     'Paranal/NACO.Lp': (14.08, 0.33),  # Stolker et al. in prep.
-                                     'Paranal/NACO.NB405': (13.91, 0.34),  # Stolker et al. in prep.
-                                     'Paranal/NACO.Mp': (13.64, 0.22),  # Stolker et al. in prep.
+                                     # 'Paranal/NACO.Lp': (14.08, 0.33),  # Stolker et al. in prep.
+                                     # 'Paranal/NACO.NB405': (13.91, 0.34),  # Stolker et al. in prep.
+                                     # 'Paranal/NACO.Mp': (13.64, 0.22),  # Stolker et al. in prep.
                                      'Keck/NIRC2.Lp': (14.64, 0.18)}},  # Wang et al. 2020
 
             'PDS 70 c': {'distance': (113.43, 0.52),

--- a/species/plot/plot_mcmc.py
+++ b/species/plot/plot_mcmc.py
@@ -168,17 +168,35 @@ def plot_posterior(tag,
 
     print(f'Plotting the posterior: {output}...', end='', flush=True)
 
-    if inc_luminosity and 'teff' in box.parameters and 'radius' in box.parameters:
+    if inc_luminosity:
         ndim += 1
 
-        teff_index = np.argwhere(np.array(box.parameters) == 'teff')[0]
-        radius_index = np.argwhere(np.array(box.parameters) == 'radius')[0]
+        if 'teff' in box.parameters and 'radius' in box.parameters:
+            teff_index = np.argwhere(np.array(box.parameters) == 'teff')[0]
+            radius_index = np.argwhere(np.array(box.parameters) == 'radius')[0]
 
-        luminosity = 4. * np.pi * (samples[..., radius_index]*constants.R_JUP)**2 * \
-            constants.SIGMA_SB * samples[..., teff_index]**4. / constants.L_SUN
+            luminosity = 4. * np.pi * (samples[..., radius_index]*constants.R_JUP)**2 * \
+                constants.SIGMA_SB * samples[..., teff_index]**4. / constants.L_SUN
 
-        samples = np.append(samples, np.log10(luminosity), axis=-1)
-        box.parameters.append('luminosity')
+            samples = np.append(samples, np.log10(luminosity), axis=-1)
+            box.parameters.append('luminosity')
+
+        elif 'teff_0' in box.parameters and 'radius_0' in box.parameters:
+            luminosity = 0.
+
+            for i in range(100):
+                teff_index = np.argwhere(np.array(box.parameters) == f'teff_{i}')
+                radius_index = np.argwhere(np.array(box.parameters) == f'radius_{i}')
+
+                if len(teff_index) > 0 and len(radius_index) > 0:
+                    luminosity += 4. * np.pi * (samples[..., radius_index[0]]*constants.R_JUP)**2 \
+                        * constants.SIGMA_SB * samples[..., teff_index[0]]**4. / constants.L_SUN
+
+                else:
+                    break
+
+            samples = np.append(samples, np.log10(luminosity), axis=-1)
+            box.parameters.append('luminosity')
 
     labels = plot_util.update_labels(box.parameters)
 

--- a/species/plot/plot_mcmc.py
+++ b/species/plot/plot_mcmc.py
@@ -174,10 +174,10 @@ def plot_posterior(tag,
         teff_index = np.argwhere(np.array(box.parameters) == 'teff')[0]
         radius_index = np.argwhere(np.array(box.parameters) == 'radius')[0]
 
-        luminosity = 4. * np.pi * (samples[:, :, radius_index]*constants.R_JUP)**2 * \
-            constants.SIGMA_SB * samples[:, :, teff_index]**4. / constants.L_SUN
+        luminosity = 4. * np.pi * (samples[..., radius_index]*constants.R_JUP)**2 * \
+            constants.SIGMA_SB * samples[..., teff_index]**4. / constants.L_SUN
 
-        samples = np.append(samples, np.log10(luminosity), axis=2)
+        samples = np.append(samples, np.log10(luminosity), axis=-1)
         box.parameters.append('luminosity')
 
     labels = plot_util.update_labels(box.parameters)

--- a/species/read/read_model.py
+++ b/species/read/read_model.py
@@ -490,19 +490,19 @@ class ReadModel:
                              f'interpolated at {model_param} because zeros are stored in the '
                              f'database.')
 
-        spec_box = box.create_box(boxtype='model',
-                                  model=self.model,
-                                  wavelength=wavelength,
-                                  flux=flux[is_finite],
-                                  parameters=model_param,
-                                  quantity=quantity)
+        model_box = box.create_box(boxtype='model',
+                                   model=self.model,
+                                   wavelength=wavelength,
+                                   flux=flux[is_finite],
+                                   parameters=model_param,
+                                   quantity=quantity)
 
-        if 'radius' in spec_box.parameters:
-            spec_box.parameters['luminosity'] = 4. * np.pi * (spec_box.parameters['radius'] * \
-                constants.R_JUP)**2 * constants.SIGMA_SB * spec_box.parameters['teff']**4. / \
+        if 'radius' in model_box.parameters:
+            model_box.parameters['luminosity'] = 4. * np.pi * (model_box.parameters['radius'] * \
+                constants.R_JUP)**2 * constants.SIGMA_SB * model_box.parameters['teff']**4. / \
                 constants.L_SUN  # (Lsun)
 
-        return spec_box
+        return model_box
 
     def get_data(self,
                  model_param):
@@ -588,19 +588,19 @@ class ReadModel:
 
         h5_file.close()
 
-        spec_box = box.create_box(boxtype='model',
-                                  model=self.model,
-                                  wavelength=wl_points,
-                                  flux=flux,
-                                  parameters=model_param,
-                                  quantity='flux')
+        model_box = box.create_box(boxtype='model',
+                                   model=self.model,
+                                   wavelength=wl_points,
+                                   flux=flux,
+                                   parameters=model_param,
+                                   quantity='flux')
 
-        if 'radius' in spec_box.parameters:
-            spec_box.parameters['luminosity'] = 4. * np.pi * (spec_box.parameters['radius'] * \
-                constants.R_JUP)**2 * constants.SIGMA_SB * spec_box.parameters['teff']**4. / \
+        if 'radius' in model_box.parameters:
+            model_box.parameters['luminosity'] = 4. * np.pi * (model_box.parameters['radius'] * \
+                constants.R_JUP)**2 * constants.SIGMA_SB * model_box.parameters['teff']**4. / \
                 constants.L_SUN  # (Lsun)
 
-        return spec_box
+        return model_box
 
     def get_flux(self,
                  model_param,

--- a/species/read/read_planck.py
+++ b/species/read/read_planck.py
@@ -165,12 +165,19 @@ class ReadPlanck:
                                     model_param[f'teff_{i}'],
                                     scaling)  # (W m-2 um-1)
 
-        return box.create_box(boxtype='model',
-                              model='planck',
-                              wavelength=wavel_points,
-                              flux=flux,
-                              parameters=model_param,
-                              quantity='flux')
+        model_box = box.create_box(boxtype='model',
+                                   model='planck',
+                                   wavelength=wavel_points,
+                                   flux=flux,
+                                   parameters=model_param,
+                                   quantity='flux')
+
+        if 'radius' in model_box.parameters:
+            model_box.parameters['luminosity'] = 4. * np.pi * (model_box.parameters['radius'] * \
+                constants.R_JUP)**2 * constants.SIGMA_SB * model_box.parameters['teff']**4. / \
+                constants.L_SUN  # (Lsun)
+
+        return model_box
 
     def get_flux(self,
                  model_param,

--- a/species/util/plot_util.py
+++ b/species/util/plot_util.py
@@ -233,12 +233,12 @@ def quantity_unit(param,
 
     if 'logg' in param:
         quantity.append('logg')
-        unit.append('')
+        unit.append(None)
         label.append(r'$\log\,g$')
 
     if 'feh' in param:
         quantity.append('feh')
-        unit.append('')
+        unit.append(None)
         label.append(r'[Fe/H]')
 
     if 'fsed' in param:
@@ -278,7 +278,7 @@ def quantity_unit(param,
 
     if 'luminosity' in param:
         quantity.append('luminosity')
-        unit.append('')
+        unit.append(None)
         label.append(r'$\log\,L$/L$_\odot$')
 
     return quantity, unit, label

--- a/species/util/plot_util.py
+++ b/species/util/plot_util.py
@@ -135,7 +135,7 @@ def update_labels(param):
 
     if 'radius' in param:
         index = param.index('radius')
-        param[index] = r'$R$ ($\mathregular{R_{Jup}}$)'
+        param[index] = r'$R$ ($\mathregular{R_{J}}$)'
 
     if 'luminosity' in param:
         index = param.index('luminosity')
@@ -168,6 +168,22 @@ def update_labels(param):
 
         elif item[0:6] == 'error_':
             param[i] = rf'$b_\mathregular{{{item[6:]}}}$'
+
+    for i in range(100):
+        if f'teff_{i}' in param:
+            index = param.index(f'teff_{i}')
+            param[index] = rf'$T_\mathregular{{{i+1}}}$ (K)'
+
+        else:
+            break
+
+    for i in range(100):
+        if f'radius_{i}' in param:
+            index = param.index(f'radius_{i}')
+            param[index] = rf'$R_\mathregular{{{i+1}}}$ ' + r'($\mathregular{R_{J}}$)'
+
+        else:
+            break
 
     return param
 
@@ -255,7 +271,7 @@ def quantity_unit(param,
         quantity.append('radius')
 
         if object_type == 'planet':
-            unit.append(r'$R_\mathregular{Jup}}$')
+            unit.append(r'$R_\mathregular{J}}$')
         elif object_type == 'star':
             unit.append(r'$R_\mathregular{\odot}}$')
 
@@ -270,7 +286,7 @@ def quantity_unit(param,
         quantity.append('mass')
 
         if object_type == 'planet':
-            unit.append(r'$M_\mathregular{Jup}$')
+            unit.append(r'$M_\mathregular{J}$')
         elif object_type == 'star':
             unit.append(r'$M_\mathregular{\odot}$')
 


### PR DESCRIPTION
- Bug fix of for loop indices in likelihood function with the use of duplicate filter names.
- Type hints and type checks added in `FitPlanck`.
- Prior added to `FitPlanck` when multiple blackbody components are fitted to enforce the temperature and radii to decrease and increase, respectively.
- Added `run_multinest` to `FitPlanck` to use nested sampling for the parameter estimation, complementing MCMC with `run_mcmc`.
- The `inc_luminosity` parameters also supports results from `FitPlanck` with multiple blackbody components.
- The luminosity is added to the `ModelBox` from `ReadPlanck.get_spectrum`.
- Updated axis labels for plots.