### PR TITLE
Updated use of spectres and timeout added to SpeciesInit

### DIFF
--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -6,7 +6,7 @@ Tutorials
 This page contains a list of tutorials which highlight some of the functionalities of `species`. These examples are also available as `Jupyter notebook <https://github.com/tomasstolker/species/tree/master/docs/tutorials>`_. Some of tutorials are still work in progress and more examples will be added in the future. Feel free to contact Tomas Stolker if you have questions regarding a specific science case (see :ref:`about` section). Please `create an issue <https://github.com/tomasstolker/species/issues>`_ on Github if you encounter any problems with the tutorials.
 
 .. warning::
-   Some of the tutorials might be outdated because ``species`` is under continuous development. If anything is unclear or causes an error, then please have a look at the `API documentation <https://species.readthedocs.io/en/latest/modules.html>`_ which is kept up-to-date.
+   Some of the tutorials might be outdated because ``species`` is under continuous development. If anything is unclear or causes an error, then please have a look at the `API documentation <https://species.readthedocs.io/en/latest/modules.html>`_ as it is kept up-to-date.
 
 .. toctree::
    :maxdepth: 1

--- a/species/core/setup.py
+++ b/species/core/setup.py
@@ -34,7 +34,7 @@ class SpeciesInit:
         print(' [DONE]')
 
         try:
-            contents = urllib.request.urlopen('https://pypi.org/pypi/species/json').read()
+            contents = urllib.request.urlopen('https://pypi.org/pypi/species/json', timeout=1.).read()
             data = json.loads(contents)
             latest_version = data['info']['version']
 

--- a/species/data/ames_cond.py
+++ b/species/data/ames_cond.py
@@ -178,14 +178,23 @@ def add_ames_cond(input_path: str,
                                                   fill=np.nan,
                                                   verbose=False)
 
-                if np.isnan(np.sum(flux_resample)):
-                    raise ValueError(f'Resampling is only possible if the new wavelength '
-                                     f'range ({wavelength[0]} - {wavelength[-1]} um) falls '
-                                     f'sufficiently far within the wavelength range '
-                                     f'({data[0, 0]} - {data[-1, 0]} um) of the input '
-                                     f'spectra.')
+                # if np.isnan(np.sum(flux_resample)):
+                #     raise ValueError(f'Resampling is only possible if the new wavelength '
+                #                      f'range ({wavelength[0]} - {wavelength[-1]} um) falls '
+                #                      f'sufficiently far within the wavelength range '
+                #                      f'({data[0, 0]} - {data[-1, 0]} um) of the input '
+                #                      f'spectra.')
+                #
+                # flux.append(flux_resample)  # (W m-2 um-1)
 
-                flux.append(flux_resample)  # (W m-2 um-1)
+                if np.isnan(np.sum(flux_resample)):
+                    flux.append(np.zeros(wavelength.shape[0]))
+
+                    warnings.warn('The wavelength range should fall within the range of the '
+                                  'original wavelength sampling. Storing zeros instead.')
+
+                else:
+                    flux.append(flux_resample)  # (W m-2 um-1)
 
     print_message = 'Adding AMES-Cond model spectra... [DONE]'
     print(f'\r{print_message:<71}')

--- a/species/data/ames_cond.py
+++ b/species/data/ames_cond.py
@@ -3,23 +3,27 @@ Module for AMES-Cond atmospheric model spectra.
 """
 
 import os
-import math
 import gzip
 import tarfile
-import warnings
 import urllib.request
 
+from typing import Optional, Tuple
+
+import h5py
 import spectres
 import numpy as np
+
+from typeguard import typechecked
 
 from species.util import data_util, read_util
 
 
-def add_ames_cond(input_path,
-                  database,
-                  wavel_range,
-                  teff_range,
-                  spec_res):
+@typechecked
+def add_ames_cond(input_path: str,
+                  database: h5py._hl.files.File,
+                  wavel_range: Tuple[float, float],
+                  teff_range: Optional[Tuple[float, float]] = None,
+                  spec_res: float = 1000.) -> None:
     """
     Function for adding the AMES-Cond atmospheric models to the database.
 
@@ -167,13 +171,21 @@ def add_ames_cond(input_path,
                 teff.append(teff_val)
                 logg.append(logg_val)
 
-                try:
-                    flux.append(spectres.spectres(wavelength, data[:, 0], data[:, 1]))
-                except ValueError:
-                    flux.append(np.zeros(wavelength.shape[0]))
+                flux_resample = spectres.spectres(wavelength,
+                                                  data[:, 0],
+                                                  data[:, 1],
+                                                  spec_errs=None,
+                                                  fill=np.nan,
+                                                  verbose=False)
 
-                    warnings.warn('The wavelength range should fall within the range of the '
-                                  'original wavelength sampling. Storing zeros instead.')
+                if np.isnan(np.sum(flux_resample)):
+                    raise ValueError(f'Resampling is only possible if the new wavelength '
+                                     f'range ({wavelength[0]} - {wavelength[-1]} um) falls '
+                                     f'sufficiently far within the wavelength range '
+                                     f'({data[0, 0]} - {data[-1, 0]} um) of the input '
+                                     f'spectra.')
+
+                flux.append(flux_resample)  # (W m-2 um-1)
 
     print_message = 'Adding AMES-Cond model spectra... [DONE]'
     print(f'\r{print_message:<71}')

--- a/species/data/ames_dusty.py
+++ b/species/data/ames_dusty.py
@@ -144,31 +144,27 @@ def add_ames_dusty(input_path: str,
                                                   fill=np.nan,
                                                   verbose=False)
 
+                # if np.isnan(np.sum(flux_resample)):
+                #     raise ValueError(f'Resampling is only possible if the new wavelength '
+                #                      f'range ({wavelength[0]} - {wavelength[-1]} um) falls '
+                #                      f'sufficiently far within the wavelength range '
+                #                      f'({data[0, 0]} - {data_wavel[-1, 0]} um) of the input '
+                #                      f'spectra.')
+                #
+                # flux.append(flux_resample)  # (W m-2 um-1)
+
                 if np.isnan(np.sum(flux_resample)):
-                    raise ValueError(f'Resampling is only possible if the new wavelength '
-                                     f'range ({wavelength[0]} - {wavelength[-1]} um) falls '
-                                     f'sufficiently far within the wavelength range '
-                                     f'({data[0, 0]} - {data_wavel[-1, 0]} um) of the input '
-                                     f'spectra.')
+                    flux.append(np.zeros(wavelength.shape[0]))
 
-                flux.append(flux_resample)  # (W m-2 um-1)
+                    warnings.warn(f'The wavelength range ({wavelength[0]:.2f}-{wavelength[-1]:.2f}'
+                                  f' um) should fall within the range of the original '
+                                  f'wavelength sampling ({data[0, 0]:.2f}-{data[-1, 0]:.2f} '
+                                  f'um). Storing zeros for the flux of Teff={teff_val} '
+                                  f'and log(g)={logg_val}, which will be corrected by the '
+                                  f'\'write_data\' function afterwards.')
 
-                # try:
-                #     flux.append(spectres.spectres(wavelength,
-                #                                   data[:, 0],
-                #                                   data[:, 1],
-                #                                   fill=0.,
-                #                                   verbose=False))
-                #
-                # except (ValueError, IndexError):
-                #     flux.append(np.zeros(wavelength.shape[0]))
-                #
-                #     warnings.warn(f'The wavelength range ({wavelength[0]:.2f}-{wavelength[-1]:.2f}'
-                #                   f' um) should fall within the range of the original '
-                #                   f'wavelength sampling ({data[0, 0]:.2f}-{data[-1, 0]:.2f} '
-                #                   f'um). Storing zeros for the flux of Teff={teff_val} '
-                #                   f'and log(g)={logg_val}, which will be corrected by the '
-                #                   f'\'write_data\' function afterwards.')
+                else:
+                    flux.append(flux_resample)  # (W m-2 um-1)
 
     print_message = 'Adding AMES-Dusty model spectra... [DONE]'
     print(f'\r{print_message:<75}')

--- a/species/data/btsettl_cifist.py
+++ b/species/data/btsettl_cifist.py
@@ -4,7 +4,6 @@ Module for BT-Settl atmospheric model spectra.
 
 import os
 import tarfile
-import warnings
 import urllib.request
 
 from typing import Optional, Tuple
@@ -23,7 +22,7 @@ def add_btsettl(input_path: str,
                 database: h5py._hl.files.File,
                 wavel_range: Optional[Tuple[float, float]],
                 teff_range: Optional[Tuple[float, float]],
-                spec_res: Optional[float]):
+                spec_res: Optional[float]) -> None:
     """
     Function for adding the BT-Settl-CIFIST atmospheric models (solar metallicity) to the database.
     The spectra had been downloaded from the Theoretical spectra web server
@@ -78,7 +77,7 @@ def add_btsettl(input_path: str,
     logg = []
     flux = []
 
-    if wavel_range is not None:
+    if wavel_range is not None and spec_res is not None:
         wavelength = read_util.create_wavelengths(wavel_range, spec_res)
     else:
         wavelength = None
@@ -103,7 +102,7 @@ def add_btsettl(input_path: str,
                 teff.append(teff_val)
                 logg.append(logg_val)
 
-                if wavel_range is None:
+                if wavel_range is None or spec_res is None:
                     if wavelength is None:
                         wavelength = np.copy(data_wavel)  # (um)
 
@@ -113,15 +112,21 @@ def add_btsettl(input_path: str,
                     flux.append(data_flux)  # (W m-2 um-1)
 
                 else:
-                    try:
-                        flux_resample = spectres.spectres(wavelength, data_wavel, data_flux)
-                        flux.append(flux_resample)  # (W m-2 um-1)
+                    flux_resample = spectres.spectres(wavelength,
+                                                      data_wavel,
+                                                      data_flux,
+                                                      spec_errs=None,
+                                                      fill=np.nan,
+                                                      verbose=False)
 
-                    except ValueError:
-                        flux.append(np.zeros(wavelength.shape[0]))  # (um)
+                    if np.isnan(np.sum(flux_resample)):
+                        raise ValueError(f'Resampling is only possible if the new wavelength '
+                                         f'range ({wavelength[0]} - {wavelength[-1]} um) falls '
+                                         f'sufficiently far within the wavelength range '
+                                         f'({data_wavel[0]} - {data_wavel[-1]} um) of the input '
+                                         f'spectra.')
 
-                        warnings.warn('The wavelength range should fall within the range of the '
-                                      'original wavelength sampling. Storing zeros instead.')
+                    flux.append(flux_resample)  # (W m-2 um-1)
 
     print_message = 'Adding BT-Settl model spectra... [DONE]'
     print(f'\r{print_message:<76}')

--- a/species/data/database.py
+++ b/species/data/database.py
@@ -301,12 +301,13 @@ class Database:
 
         h5_file.close()
 
+    @typechecked
     def add_model(self,
-                  model,
-                  wavel_range=None,
-                  spec_res=None,
-                  teff_range=None,
-                  data_folder=None):
+                  model: str,
+                  wavel_range: Optional[Tuple[float, float]] = None,
+                  spec_res: Optional[float] = None,
+                  teff_range: Optional[Tuple[float, float]] = None,
+                  data_folder: Optional[str] = None) -> None:
         """
         Parameters
         ----------
@@ -316,11 +317,12 @@ class Database:
             'petitcode-hot-clear', 'petitcode-hot-cloudy', or 'exo-rem').
         wavel_range : tuple(float, float), None
             Wavelength range (um). Optional for the DRIFT-PHOENIX and petitCODE models. For
-            these models, the original wavelength points are used if set to None.
-            which case the argument can be set to None.
+            these models, the original wavelength points are used if set to ``None``.
+            which case the argument can be set to ``None``.
         spec_res : float, None
-            Spectral resolution. Optional for the DRIFT-PHOENIX and petitCODE models, in which
-            case the argument is only used if ``wavel_range`` is not None.
+            Spectral resolution. The parameter is optional for the DRIFT-PHOENIX, petitCODE,
+            BT-Settl, and Exo-REM models. The argument is only used if ``wavel_range`` is not
+            ``None``.
         teff_range : tuple(float, float), None
             Effective temperature range (K). Setting the value to None for will add all available
             temperatures.

--- a/species/data/petitcode.py
+++ b/species/data/petitcode.py
@@ -7,18 +7,24 @@ import zipfile
 import warnings
 import urllib.request
 
+from typing import Optional, Tuple
+
+import h5py
 import spectres
 import numpy as np
+
+from typeguard import typechecked
 
 from species.core import constants
 from species.util import data_util, read_util
 
 
-def add_petitcode_cool_clear(input_path,
-                             database,
-                             wavel_range=None,
-                             teff_range=None,
-                             spec_res=1000.):
+@typechecked
+def add_petitcode_cool_clear(input_path: str,
+                             database: h5py._hl.files.File,
+                             wavel_range: Optional[Tuple[float, float]] = None,
+                             teff_range: Optional[Tuple[float, float]] = None,
+                             spec_res: Optional[float] = 1000.) -> None:
     """
     Function for adding the petitCODE cool clear atmospheric models to the database.
 
@@ -136,11 +142,12 @@ def add_petitcode_cool_clear(input_path,
                          data_sorted)
 
 
-def add_petitcode_cool_cloudy(input_path,
-                              database,
-                              wavel_range=None,
-                              teff_range=None,
-                              spec_res=1000.):
+@typechecked
+def add_petitcode_cool_cloudy(input_path: str,
+                              database: h5py._hl.files.File,
+                              wavel_range: Optional[Tuple[float, float]] = None,
+                              teff_range: Optional[Tuple[float, float]] = None,
+                              spec_res: Optional[float] = 1000.) -> None:
     """
     Function for adding the petitCODE cool cloudy atmospheric models to the database.
 
@@ -261,12 +268,13 @@ def add_petitcode_cool_cloudy(input_path,
                          data_sorted)
 
 
-def add_petitcode_hot_clear(input_path,
-                            database,
-                            data_folder,
-                            wavel_range=None,
-                            teff_range=None,
-                            spec_res=1000.):
+@typechecked
+def add_petitcode_hot_clear(input_path: str,
+                            database: h5py._hl.files.File,
+                            data_folder: str,
+                            wavel_range: Optional[Tuple[float, float]] = None,
+                            teff_range: Optional[Tuple[float, float]] = None,
+                            spec_res: Optional[float] = 1000.) -> None:
     """
     Function for adding the petitCODE hot clear atmospheric models to the database.
 
@@ -369,12 +377,13 @@ def add_petitcode_hot_clear(input_path,
                          data_sorted)
 
 
-def add_petitcode_hot_cloudy(input_path,
-                             database,
-                             data_folder,
-                             wavel_range=None,
-                             teff_range=None,
-                             spec_res=1000.):
+@typechecked
+def add_petitcode_hot_cloudy(input_path: str,
+                             database: h5py._hl.files.File,
+                             data_folder: str,
+                             wavel_range: Optional[Tuple[float, float]] = None,
+                             teff_range: Optional[Tuple[float, float]] = None,
+                             spec_res: Optional[float] = 1000.) -> None:
     """
     Function for adding the petitCODE hot cloudy atmospheric models to the database.
 

--- a/species/plot/plot_mcmc.py
+++ b/species/plot/plot_mcmc.py
@@ -181,8 +181,6 @@ def plot_posterior(tag: str,
     print(f'Plotting the posterior: {output}...', end='', flush=True)
 
     if inc_luminosity:
-        ndim += 1
-
         if 'teff' in box.parameters and 'radius' in box.parameters:
             teff_index = np.argwhere(np.array(box.parameters) == 'teff')[0]
             radius_index = np.argwhere(np.array(box.parameters) == 'radius')[0]
@@ -192,6 +190,7 @@ def plot_posterior(tag: str,
 
             samples = np.append(samples, np.log10(luminosity), axis=-1)
             box.parameters.append('luminosity')
+            ndim += 1
 
         elif 'teff_0' in box.parameters and 'radius_0' in box.parameters:
             luminosity = 0.
@@ -209,6 +208,7 @@ def plot_posterior(tag: str,
 
             samples = np.append(samples, np.log10(luminosity), axis=-1)
             box.parameters.append('luminosity')
+            ndim += 1
 
             teff_index_0 = np.argwhere(np.array(box.parameters) == 'teff_0')
             radius_index_0 = np.argwhere(np.array(box.parameters) == 'radius_0')
@@ -221,10 +221,6 @@ def plot_posterior(tag: str,
 
             luminosity_1 = 4. * np.pi * (samples[..., radius_index_1[0]]*constants.R_JUP)**2 \
                 * constants.SIGMA_SB * samples[..., teff_index_1[0]]**4. / constants.L_SUN
-
-            # samples = np.append(samples, np.log10(luminosity), axis=-1)
-            # box.parameters.append('luminosity')
-            # ndim += 1
 
             samples = np.append(samples, np.log10(luminosity_0/luminosity_1), axis=-1)
             box.parameters.append('luminosity_ratio')

--- a/species/plot/plot_mcmc.py
+++ b/species/plot/plot_mcmc.py
@@ -210,6 +210,26 @@ def plot_posterior(tag: str,
             samples = np.append(samples, np.log10(luminosity), axis=-1)
             box.parameters.append('luminosity')
 
+            teff_index_0 = np.argwhere(np.array(box.parameters) == 'teff_0')
+            radius_index_0 = np.argwhere(np.array(box.parameters) == 'radius_0')
+
+            teff_index_1 = np.argwhere(np.array(box.parameters) == 'teff_1')
+            radius_index_1 = np.argwhere(np.array(box.parameters) == 'radius_1')
+
+            luminosity_0 = 4. * np.pi * (samples[..., radius_index_0[0]]*constants.R_JUP)**2 \
+                * constants.SIGMA_SB * samples[..., teff_index_0[0]]**4. / constants.L_SUN
+
+            luminosity_1 = 4. * np.pi * (samples[..., radius_index_1[0]]*constants.R_JUP)**2 \
+                * constants.SIGMA_SB * samples[..., teff_index_1[0]]**4. / constants.L_SUN
+
+            # samples = np.append(samples, np.log10(luminosity), axis=-1)
+            # box.parameters.append('luminosity')
+            # ndim += 1
+
+            samples = np.append(samples, np.log10(luminosity_0/luminosity_1), axis=-1)
+            box.parameters.append('luminosity_ratio')
+            ndim += 1
+
     labels = plot_util.update_labels(box.parameters)
 
     samples = samples.reshape((-1, ndim))

--- a/species/plot/plot_spectrum.py
+++ b/species/plot/plot_spectrum.py
@@ -33,7 +33,7 @@ def plot_spectrum(boxes: list,
                   offset: Optional[Tuple[float, float]] = None,
                   legend: Union[str, dict, Tuple[float, float],
                                 List[Optional[Union[dict, str, Tuple[float, float]]]]] = None,
-                  figsize: Optional[Tuple[float, float]] = (7., 5.),
+                  figsize: Optional[Tuple[float, float]] = (10., 5.),
                   object_type: str = 'planet',
                   quantity: str = 'flux density',
                   output: str = 'spectrum.pdf'):

--- a/species/read/read_model.py
+++ b/species/read/read_model.py
@@ -225,6 +225,7 @@ class ReadModel:
 
                     if self.filter_name is not None:
                         flux_new[i, j] = self.get_flux(model_param)[0]
+
                     else:
                         flux_new[i, j, :] = self.get_model(model_param,
                                                            spec_res=spec_res,
@@ -243,6 +244,7 @@ class ReadModel:
 
                         if self.filter_name is not None:
                             flux_new[i, j, k] = self.get_flux(model_param)[0]
+
                         else:
                             flux_new[i, j, k, :] = self.get_model(model_param,
                                                                   spec_res=spec_res,
@@ -263,6 +265,7 @@ class ReadModel:
 
                             if self.filter_name is not None:
                                 flux_new[i, j, k, m] = self.get_flux(model_param)[0]
+
                             else:
                                 flux_new[i, j, k, m, :] = self.get_model(
                                     model_param, spec_res=spec_res, wavel_resample=wavel_resample,
@@ -284,6 +287,7 @@ class ReadModel:
 
                                 if self.filter_name is not None:
                                     flux_new[i, j, k, m, n] = self.get_flux(model_param)[0]
+
                                 else:
                                     flux_new[i, j, k, m, n, :] = self.get_model(
                                         model_param, spec_res=spec_res,
@@ -498,7 +502,7 @@ class ReadModel:
                                      self.wl_points,
                                      flux,
                                      spec_errs=None,
-                                     fill=0.,
+                                     fill=np.nan,
                                      verbose=True)
 
         elif spec_res is not None and not smooth:
@@ -521,7 +525,7 @@ class ReadModel:
                                      self.wl_points,
                                      flux,
                                      spec_errs=None,
-                                     fill=0.,
+                                     fill=np.nan,
                                      verbose=True)
 
         if magnitude:
@@ -549,7 +553,7 @@ class ReadModel:
                                              calibbox.wavelength,
                                              calibbox.flux,
                                              spec_errs=calibbox.error,
-                                             fill=0.,
+                                             fill=np.nan,
                                              verbose=True)
 
             flux = -2.5*np.log10(flux/flux_vega)
@@ -557,17 +561,22 @@ class ReadModel:
         else:
             quantity = 'flux'
 
-        is_finite = np.where(np.isfinite(flux))[0]
+        if np.isnan(np.sum(flux)):
+            warnings.warn(f'The resampled spectrum contains {np.sum(np.isnan(flux))} NaNs, '
+                          f'probably because the original wavelength range does not fully '
+                          f'encompass the new wavelength range.')
 
-        if wavel_resample is None:
-            wavelength = self.wl_points[is_finite]
-        else:
-            wavelength = wavel_resample[is_finite]
-
-        if wavelength.shape[0] == 0:
-            raise ValueError(f'The model spectrum is empty. Perhaps the grid could not be '
-                             f'interpolated at {model_param} because zeros are stored in the '
-                             f'database.')
+        # is_finite = np.where(np.isfinite(flux))[0]
+        #
+        # if wavel_resample is None:
+        #     wavelength = self.wl_points[is_finite]
+        # else:
+        #     wavelength = wavel_resample[is_finite]
+        #
+        # if wavelength.shape[0] == 0:
+        #     raise ValueError(f'The model spectrum is empty. Perhaps the grid could not be '
+        #                      f'interpolated at {model_param} because zeros are stored in the '
+        #                      f'database.')
 
         model_box = box.create_box(boxtype='model',
                                    model=self.model,

--- a/species/read/read_model.py
+++ b/species/read/read_model.py
@@ -566,6 +566,11 @@ class ReadModel:
                           f'probably because the original wavelength range does not fully '
                           f'encompass the new wavelength range.')
 
+        if wavel_resample is None:
+            wavelength = self.wl_points
+        else:
+            wavelength = wavel_resample
+
         # is_finite = np.where(np.isfinite(flux))[0]
         #
         # if wavel_resample is None:
@@ -581,7 +586,7 @@ class ReadModel:
         model_box = box.create_box(boxtype='model',
                                    model=self.model,
                                    wavelength=wavelength,
-                                   flux=flux[is_finite],
+                                   flux=flux,
                                    parameters=model_param,
                                    quantity=quantity)
 

--- a/species/util/plot_util.py
+++ b/species/util/plot_util.py
@@ -150,6 +150,10 @@ def update_labels(param: List[str]) -> List[str]:
         index = param.index('luminosity')
         param[index] = r'$\log\,L$/L$_\odot$'
 
+    if 'luminosity_ratio' in param:
+        index = param.index('luminosity_ratio')
+        param[index] = r'$\log\,L_1/L_2$'
+
     if 'dust_radius' in param:
         index = param.index('dust_radius')
         param[index] = r'$\log\,r_\mathregular{g}/\mathrm{µm}$'


### PR DESCRIPTION
- Removed the try-except when model spectra are imported and (optionally) resampled. With the new version of `spectres` the error was changed into a warning and a `fill` value (set to NaN in `species`) is used outside the wavelength range of the input data.

- Added a timeout to `SpeciesInit` for poor internet connections.

- Added the luminosity ratio to the posterior plot when fitting two blackbody components.