### PR TITLE
Extinction parameters for a power-law size distribution of grains

### DIFF
--- a/species/analysis/fit_model.py
+++ b/species/analysis/fit_model.py
@@ -380,7 +380,7 @@ class FitModel:
         bounds : dict(str, tuple(float, float)), None
             The boundaries that are used for the uniform priors.
 
-            Atmospheric model parameters (e.g. ``model='bt-settl``):
+            Atmospheric model parameters (e.g. ``model='bt-settl'``):
 
                  - Boundaries are provided as tuple of two floats. For example,
                    ``bounds={'teff': (1000, 1500.), 'logg': (3.5, 5.), 'radius': (0.8, 1.2)}``.
@@ -416,9 +416,9 @@ class FitModel:
 
                  - The dictionary key should be equal to the database tag of the spectrum. For
                    example, ``{'SPHERE': ((0.8, 1.2), (-18., -14.))}`` if the spectrum is stored as
-                   ``sphere`` with :func:`~species.data.database.Database.add_object`.
+                   ``'SPHERE'`` with :func:`~species.data.database.Database.add_object`.
 
-                 - Each of the two scaling parameters can be set to ``None`` in which case the
+                 - Each of the two calibration parameters can be set to ``None`` in which case the
                    parameter is not used. For example, ``bounds={'SPHERE': ((0.8, 1.2), None)}``.
 
                  - No calibration parameters are fitted if the spectrum name is not included in
@@ -426,8 +426,8 @@ class FitModel:
 
             ISM extinction parameters:
 
-                 - There are two approaches of fitting extinction. The first is with the empirical
-                   relation from Cardelli et al. (1989) for ISM extinction.
+                 - There are three approaches for fitting extinction. The first is with the
+                   empirical relation from Cardelli et al. (1989) for ISM extinction.
 
                  - The extinction is parametrized by the V band extinction, A_V (``ism_ext``), and
                    the reddening, R_V (``ism_red``).
@@ -436,31 +436,55 @@ class FitModel:
                    ``bounds`` dictionary, for example ``bounds={'ism_ext': (0., 10.),
                    'ism_red': (0., 20.)}``.
 
-                 - Only supported by `run_multinest`.
+                 - Only supported by ``run_multinest``.
 
-            Size distribution extinction parameters:
+            Log-normal size distribution:
 
                  - The second approach is fitting the extinction of a log-normal size distribution
                    of grains with a crystalline MgSiO3 composition, and a homogeneous, spherical
                    structure.
 
                  - The size distribution is parameterized with a mean geometric radius
-                   (``dust_radius`` in um) and a geometric standard deviation (``dust_sigma``,
-                   dimensionless).
+                   (``lognorm_radius`` in um) and a geometric standard deviation
+                   (``lognorm_sigma``, dimensionless).
 
-                 - The extinction (``dust_ext``) is fitted in the V band (A_V in mag) and the
+                 - The extinction (``lognorm_ext``) is fitted in the V band (A_V in mag) and the
                    wavelength-dependent extinction cross sections are interpolated from a
                    pre-tabulated grid.
 
-                 - The prior boundaries of ``dust_radius``, ``dust_sigma``, and ``dust_ext`` should
-                   be provided in the ``bounds`` dictionary, for example
-                   ``bounds={'dust_radius': (0.01, 10.), 'dust_sigma': (1.2, 10.),
-                   'dust_ext': (0., 5.)}``.
+                 - The prior boundaries of ``lognorm_radius``, ``lognorm_sigma``, and
+                   ``lognorm_ext`` should be provided in the ``bounds`` dictionary, for example
+                   ``bounds={'lognorm_radius': (0.01, 10.), 'lognorm_sigma': (1.2, 10.),
+                   'lognorm_ext': (0., 5.)}``.
 
-                 - A uniform prior is used for ``dust_sigma`` and ``dust_ext``, and a log-uniform
-                   prior for ``dust_radius``.
+                 - A uniform prior is used for ``lognorm_sigma`` and ``lognorm_ext``, and a
+                   log-uniform prior for ``lognorm_radius``.
 
-                 - Only supported by `run_multinest`.
+                 - Only supported by ``run_multinest``.
+
+            Power-law size distribution:
+
+                 - The third approach is fitting the extinction of a power-law size distribution
+                   of grains, again with a crystalline MgSiO3 composition, and a homogeneous,
+                   spherical structure.
+
+                 - The size distribution is parameterized with a minimum radius (``powerlaw_min``
+                   in um), a maximum radius (``powerlaw_max`` in um), and a power-law exponent
+                   (``powerlaw_exp``, dimensionless).
+
+                 - The extinction (``powerlaw_ext``) is fitted in the V band (A_V in mag) and the
+                   wavelength-dependent extinction cross sections are interpolated from a
+                   pre-tabulated grid.
+
+                 - The prior boundaries of ``powerlaw_min``, ``powerlaw_max``, ``powerlaw_exp``,
+                   and ``powerlaw_ext`` should be provided in the ``bounds`` dictionary, for
+                   example ``bounds={'powerlaw_min': (0.001, 0.1), 'powerlaw_max': (0.5, 10.),
+                   'powerlaw_exp': (-5., 5.), 'powerlaw_ext': (0., 5.)}``.
+
+                 - A uniform prior is used for ``powerlaw_exp`` and ``powerlaw_ext``, and a
+                   log-uniform prior for ``powerlaw_min`` and ``powerlaw_max``.
+
+                 - Only supported by ``run_multinest``.
 
         inc_phot : bool, list(str)
             Include photometric data in the fit. If a boolean, either all (``True``) or none
@@ -659,18 +683,34 @@ class FitModel:
                 if item in self.bounds:
                     del self.bounds[item]
 
-        if 'dust_radius' in self.bounds and 'dust_sigma' in self.bounds and \
-                'dust_ext' in self.bounds:
+        if 'lognorm_radius' in self.bounds and 'lognorm_sigma' in self.bounds and \
+                'lognorm_ext' in self.bounds:
 
-            self.cross_sections, self.dust_radius, self.dust_sigma = \
-                dust_util.interpolate_dust(inc_phot, inc_spec, self.spectrum)
+            self.cross_sections, _, _ = dust_util.interp_lognorm(inc_phot, inc_spec, self.spectrum)
 
-            self.modelpar.append('dust_radius')
-            self.modelpar.append('dust_sigma')
-            self.modelpar.append('dust_ext')
+            self.modelpar.append('lognorm_radius')
+            self.modelpar.append('lognorm_sigma')
+            self.modelpar.append('lognorm_ext')
 
-            self.bounds['dust_radius'] = (np.log10(self.bounds['dust_radius'][0]),
-                                          np.log10(self.bounds['dust_radius'][1]))
+            self.bounds['lognorm_radius'] = (np.log10(self.bounds['lognorm_radius'][0]),
+                                             np.log10(self.bounds['lognorm_radius'][1]))
+
+        elif 'powerlaw_min' in self.bounds and 'powerlaw_max' in self.bounds and \
+                'powerlaw_exp' in self.bounds and 'powerlaw_ext' in self.bounds:
+
+            self.cross_sections, _, _, _ = dust_util.interp_powerlaw(
+                inc_phot, inc_spec, self.spectrum)
+
+            self.modelpar.append('powerlaw_min')
+            self.modelpar.append('powerlaw_max')
+            self.modelpar.append('powerlaw_exp')
+            self.modelpar.append('powerlaw_ext')
+
+            self.bounds['powerlaw_min'] = (np.log10(self.bounds['powerlaw_min'][0]),
+                                           np.log10(self.bounds['powerlaw_min'][1]))
+
+            self.bounds['powerlaw_max'] = (np.log10(self.bounds['powerlaw_max'][0]),
+                                           np.log10(self.bounds['powerlaw_max'][1]))
 
         else:
             self.cross_sections = None
@@ -776,15 +816,6 @@ class FitModel:
 
             if item in guess:
                 del guess[item]
-
-        if 'dust_radius' in self.bounds:
-            sigma['dust_radius'] = 0.01  # (dex)
-
-        if 'dust_sigma' in self.bounds:
-            sigma['dust_sigma'] = 0.01
-
-        if 'dust_mag' in self.bounds:
-            sigma['dust_mag'] = 0.01
 
         initial = np.zeros((nwalkers, ndim))
 
@@ -965,7 +996,10 @@ class FitModel:
                 elif item[:9] == 'corr_amp_' and item[9:] in self.spectrum:
                     corr_amp[item[9:]] = cube[cube_index[item]]
 
-                elif item[:5] == 'dust_':
+                elif item[:8] == 'lognorm_':
+                    dust_param[item] = cube[cube_index[item]]
+
+                elif item[:9] == 'powerlaw_':
                     dust_param[item] = cube[cube_index[item]]
 
                 elif item[:4] == 'ism_':
@@ -1012,20 +1046,18 @@ class FitModel:
                     else:
                         ln_like += -0.5 * (cube[cube_index[key]] - value[0])**2 / value[1]**2
 
-            if 'dust_ext' in dust_param:
-                # dn_dr, r_test = dust_util.log_normal_distribution(
-                #     10.**dust_param['dust_radius'], dust_param['dust_sigma'], (-15, 15, 10000))
-
-                # index = np.where(dn_dr/np.amax(dn_dr) > 1e-3)[0]
-
-                # if r_test[index[0]] < 1e-3:
-                #     # The minimum grain radius of the distribution is smaller than 1 nm
-                #     return -np.inf
-
+            if 'lognorm_ext' in dust_param:
                 cross_tmp = self.cross_sections['Generic/Bessell.V'](
-                    dust_param['dust_sigma'], 10.**dust_param['dust_radius'])[0]
+                    dust_param['lognorm_sigma'], 10.**dust_param['lognorm_radius'])[0]
 
-                n_grains = dust_param['dust_ext'] / cross_tmp / 2.5 / np.log10(np.exp(1.))
+                n_grains = dust_param['lognorm_ext'] / cross_tmp / 2.5 / np.log10(np.exp(1.))
+
+            elif 'powerlaw_ext' in dust_param:
+                cross_tmp = self.cross_sections['Generic/Bessell.V'](
+                    (10.**dust_param['powerlaw_min'], 10.**dust_param['powerlaw_max'],
+                     dust_param['powerlaw_exp']))
+
+                n_grains = dust_param['powerlaw_ext'] / cross_tmp / 2.5 / np.log10(np.exp(1.))
 
             for i, obj_item in enumerate(self.objphot):
                 if self.model == 'planck':
@@ -1036,9 +1068,16 @@ class FitModel:
                     phot_flux = self.modelphot[i].spectrum_interp(list(param_dict.values()))[0][0]
                     phot_flux *= flux_scaling
 
-                if 'dust_ext' in dust_param:
+                if 'lognorm_ext' in dust_param:
                     cross_tmp = self.cross_sections[self.modelphot[i].filter_name](
-                        dust_param['dust_sigma'], 10.**dust_param['dust_radius'])[0]
+                        dust_param['lognorm_sigma'], 10.**dust_param['lognorm_radius'])[0]
+
+                    phot_flux *= np.exp(-cross_tmp*n_grains)
+
+                elif 'powerlaw_ext' in dust_param:
+                    cross_tmp = self.cross_sections[self.modelphot[i].filter_name](
+                        (10.**dust_param['powerlaw_min'], 10.**dust_param['powerlaw_max'],
+                         dust_param['powerlaw_exp']))
 
                     phot_flux *= np.exp(-cross_tmp*n_grains)
 
@@ -1092,10 +1131,18 @@ class FitModel:
                     model_flux = self.modelspec[i].spectrum_interp(list(param_dict.values()))[0, :]
                     model_flux *= flux_scaling
 
-                if 'dust_ext' in dust_param:
+                if 'lognorm_ext' in dust_param:
                     for j, cross_item in enumerate(self.cross_sections[item]):
-                        cross_tmp = cross_item(dust_param['dust_sigma'],
-                                               10.**dust_param['dust_radius'])
+                        cross_tmp = cross_item(dust_param['lognorm_sigma'],
+                                               10.**dust_param['lognorm_radius'])
+
+                        model_flux[j] *= np.exp(-cross_tmp*n_grains)
+
+                elif 'powerlaw_ext' in dust_param:
+                    for j, cross_item in enumerate(self.cross_sections[item]):
+                        cross_tmp = cross_item((10.**dust_param['powerlaw_min'],
+                                                10.**dust_param['powerlaw_max'],
+                                                dust_param['powerlaw_exp']))
 
                         model_flux[j] *= np.exp(-cross_tmp*n_grains)
 

--- a/species/data/database.py
+++ b/species/data/database.py
@@ -171,9 +171,9 @@ class Database:
     @typechecked
     def add_dust(self) -> None:
         """
-        Function for adding optical constants of MgSiO3 and Fe to the database. The optical
-        constants have been compiled by Mollière et al. (2019) for petitRADTRANS from the
-        following sources:
+        Function for adding optical constants of MgSiO3 and Fe, and MgSiO3 cross sections for
+        a log-normal and power-law size distribution to the database. The optical constants have
+        been compiled by Mollière et al. (2019) for petitRADTRANS from the following sources:
 
         - MgSiO3, crystalline
             - Scott & Duley (1996), ApJS, 105, 401

--- a/species/data/dust.py
+++ b/species/data/dust.py
@@ -145,7 +145,7 @@ def add_cross_sections(input_path: str,
 
     data_file = os.path.join(input_path, 'powerlaw_mgsio3_c_ext.fits')
 
-    print('Downloading power-law dust cross sections (552 kB)...', end='', flush=True)
+    print('Downloading power-law dust cross sections (231 kB)...', end='', flush=True)
     urllib.request.urlretrieve(url, data_file)
     print(' [DONE]')
 
@@ -158,13 +158,10 @@ def add_cross_sections(input_path: str,
         database.create_dataset('dust/powerlaw/mgsio3/crystalline/wavelength/',
                                 data=hdu_list[1].data)
 
-        database.create_dataset('dust/powerlaw/mgsio3/crystalline/radius_min/',
+        database.create_dataset('dust/powerlaw/mgsio3/crystalline/radius_max/',
                                 data=hdu_list[2].data)
 
-        database.create_dataset('dust/powerlaw/mgsio3/crystalline/radius_max/',
-                                data=hdu_list[3].data)
-
         database.create_dataset('dust/powerlaw/mgsio3/crystalline/exponent/',
-                                data=hdu_list[4].data)
+                                data=hdu_list[3].data)
 
     print(' [DONE]')

--- a/species/data/dust.py
+++ b/species/data/dust.py
@@ -97,7 +97,8 @@ def add_optical_constants(input_path: str,
 def add_cross_sections(input_path: str,
                        database: h5py._hl.files.File) -> None:
     """
-    Function for adding the extinction cross section of crystalline MgSiO3 to the database.
+    Function for adding the extinction cross section of crystalline MgSiO3 for a log-normal and
+    power-law size distribution to the database.
 
     Parameters
     ----------
@@ -115,21 +116,55 @@ def add_cross_sections(input_path: str,
     if not os.path.exists(input_path):
         os.makedirs(input_path)
 
-    url = 'https://people.phys.ethz.ch/~stolkert/species/mgsio3_crystalline_c_ext.fits'
+    url = 'https://people.phys.ethz.ch/~stolkert/species/lognorm_mgsio3_c_ext.fits'
 
-    data_file = os.path.join(input_path, 'mgsio3_crystalline_c_ext.fits')
+    data_file = os.path.join(input_path, 'lognorm_mgsio3_c_ext.fits')
 
-    # if not os.path.isfile(data_file):
-    print('Downloading dust cross sections (23 kB)...', end='', flush=True)
+    print('Downloading log-normal dust cross sections (231 kB)...', end='', flush=True)
     urllib.request.urlretrieve(url, data_file)
     print(' [DONE]')
 
-    print('Adding dust cross sections...', end='')
+    print('Adding log-normal dust cross sections...', end='')
 
-    with fits.open(os.path.join(input_path, 'mgsio3_crystalline_c_ext.fits')) as hdu_list:
-        database.create_dataset('dust/mgsio3/crystalline/cross_section/', data=hdu_list[0].data)
-        database.create_dataset('dust/mgsio3/crystalline/wavelength/', data=hdu_list[1].data)
-        database.create_dataset('dust/mgsio3/crystalline/radius/', data=hdu_list[2].data)
-        database.create_dataset('dust/mgsio3/crystalline/sigma/', data=hdu_list[3].data)
+    with fits.open(os.path.join(input_path, 'lognorm_mgsio3_c_ext.fits')) as hdu_list:
+        database.create_dataset('dust/lognorm/mgsio3/crystalline/cross_section/',
+                                data=hdu_list[0].data)
+
+        database.create_dataset('dust/lognorm/mgsio3/crystalline/wavelength/',
+                                data=hdu_list[1].data)
+
+        database.create_dataset('dust/lognorm/mgsio3/crystalline/radius_g/',
+                                data=hdu_list[2].data)
+
+        database.create_dataset('dust/lognorm/mgsio3/crystalline/sigma_g/',
+                                data=hdu_list[3].data)
+
+    print(' [DONE]')
+
+    url = 'https://people.phys.ethz.ch/~stolkert/species/powerlaw_mgsio3_c_ext.fits'
+
+    data_file = os.path.join(input_path, 'powerlaw_mgsio3_c_ext.fits')
+
+    print('Downloading power-law dust cross sections (552 kB)...', end='', flush=True)
+    urllib.request.urlretrieve(url, data_file)
+    print(' [DONE]')
+
+    print('Adding power-law dust cross sections...', end='')
+
+    with fits.open(os.path.join(input_path, 'powerlaw_mgsio3_c_ext.fits')) as hdu_list:
+        database.create_dataset('dust/powerlaw/mgsio3/crystalline/cross_section/',
+                                data=hdu_list[0].data)
+
+        database.create_dataset('dust/powerlaw/mgsio3/crystalline/wavelength/',
+                                data=hdu_list[1].data)
+
+        database.create_dataset('dust/powerlaw/mgsio3/crystalline/radius_min/',
+                                data=hdu_list[2].data)
+
+        database.create_dataset('dust/powerlaw/mgsio3/crystalline/radius_max/',
+                                data=hdu_list[3].data)
+
+        database.create_dataset('dust/powerlaw/mgsio3/crystalline/exponent/',
+                                data=hdu_list[4].data)
 
     print(' [DONE]')

--- a/species/plot/plot_color.py
+++ b/species/plot/plot_color.py
@@ -380,7 +380,7 @@ def plot_color_magnitude(boxes: list,
                                                     item[1],
                                                     composition=item[2],
                                                     structure='crystalline',
-                                                    radius=item[3])
+                                                    radius_g=item[3])
 
             delta_x = ext_1 - ext_2
             delta_y = item[1][1]
@@ -840,13 +840,13 @@ def plot_color_color(boxes: list,
                                                     item[2],
                                                     composition=item[3],
                                                     structure='crystalline',
-                                                    radius=item[4])
+                                                    radius_g=item[4])
 
             ext_3, ext_4 = dust_util.calc_reddening(item[1],
                                                     item[2],
                                                     composition=item[3],
                                                     structure='crystalline',
-                                                    radius=item[4])
+                                                    radius_g=item[4])
 
             delta_x = ext_1 - ext_2
             delta_y = ext_3 - ext_4

--- a/species/plot/plot_mcmc.py
+++ b/species/plot/plot_mcmc.py
@@ -32,7 +32,7 @@ def plot_walkers(tag: str,
     Parameters
     ----------
     tag : str
-        Database tag with the MCMC samples.
+        Database tag with the samples.
     nsteps : int, None
         Number of steps that are plotted. All steps are plotted if set to ``None``.
     offset : tuple(float, float), None
@@ -130,7 +130,7 @@ def plot_posterior(tag: str,
     Parameters
     ----------
     tag : str
-        Database tag with the MCMC samples.
+        Database tag with the samples.
     burnin : int, None
         Number of burnin steps to exclude. All samples are used if set to ``None``.
     title : str, None
@@ -338,7 +338,7 @@ def plot_photometry(tag,
     Parameters
     ----------
     tag : str
-        Database tag with the MCMC samples.
+        Database tag with the samples.
     filter_id : str
         Filter ID.
     burnin : int, None
@@ -400,12 +400,12 @@ def plot_size_distributions(tag: str,
                             offset: Optional[Tuple[float, float]] = None,
                             output: str = 'size_distributions.pdf') -> None:
     """
-    Function to plot random samples of the log-normal size distribution.
+    Function to plot random samples of the log-normal or power-law size distribution.
 
     Parameters
     ----------
     tag : str
-        Database tag with the MCMC samples.
+        Database tag with the samples.
     burnin : int, None
         Number of burnin steps to exclude. All samples are used if set to ``None``. Only required
         after running MCMC with :func:`~species.analysis.fit_model.FitModel.run_mcmc`.
@@ -435,11 +435,9 @@ def plot_size_distributions(tag: str,
     species_db = database.Database()
     box = species_db.get_samples(tag)
 
-    if 'dust_radius' not in box.parameters:
-        raise ValueError('The SamplesBox does not contain the \'dust_radius\' parameter.')
-
-    if 'dust_sigma' not in box.parameters:
-        raise ValueError('The SamplesBox does not contain the \'dust_sigma\' parameter.')
+    if 'lognorm_radius' not in box.parameters and 'powerlaw_min' not in box.parameters:
+        raise ValueError('The SamplesBox does not contain extinction parameter for a log-normal '
+                         'or power-law size distribution.')
 
     samples = box.samples
 
@@ -458,11 +456,21 @@ def plot_size_distributions(tag: str,
         ran_step = np.random.randint(samples.shape[1], size=random)
         samples = samples[ran_walker, ran_step, :]
 
-    log_r_index = box.parameters.index('dust_radius')
-    sigma_index = box.parameters.index('dust_sigma')
+    if 'lognorm_radius' in box.parameters:
+        log_r_index = box.parameters.index('lognorm_radius')
+        sigma_index = box.parameters.index('lognorm_sigma')
 
-    log_r_g = samples[:, log_r_index]
-    sigma_g = samples[:, sigma_index]
+        log_r_g = samples[:, log_r_index]
+        sigma_g = samples[:, sigma_index]
+
+    if 'powerlaw_min' in box.parameters:
+        r_min_index = box.parameters.index('powerlaw_min')
+        r_max_index = box.parameters.index('powerlaw_max')
+        exponent_index = box.parameters.index('powerlaw_exp')
+
+        r_min = samples[:, r_min_index]
+        r_max = samples[:, r_max_index]
+        exponent = samples[:, exponent_index]
 
     plt.figure(1, figsize=(6, 3))
     gridsp = mpl.gridspec.GridSpec(1, 1)
@@ -483,6 +491,9 @@ def plot_size_distributions(tag: str,
 
     ax.set_xscale('log')
 
+    if 'powerlaw_min' in box.parameters:
+        ax.set_yscale('log')
+
     if offset is not None:
         ax.get_xaxis().set_label_coords(0.5, offset[0])
         ax.get_yaxis().set_label_coords(offset[1], 0.5)
@@ -492,13 +503,12 @@ def plot_size_distributions(tag: str,
         ax.get_yaxis().set_label_coords(-0.09, 0.5)
 
     for i in range(samples.shape[0]):
-        test_range = (-15, 15, 10000)
-        dn_dr, r_test = dust_util.log_normal_distribution(10.**log_r_g[i], sigma_g[i], test_range)
+        if 'lognorm_radius' in box.parameters:
+            dn_dr, _, radii = dust_util.log_normal_distribution(10.**log_r_g[i], sigma_g[i], 1000)
 
-        index = np.where(dn_dr/np.amax(dn_dr) > 1e-3)[0]
-
-        radius_range = (np.log10(r_test[index[0]]), np.log10(r_test[index[-1]]), 1000)
-        dn_dr, radii = dust_util.log_normal_distribution(10.**log_r_g[i], sigma_g[i], radius_range)
+        elif 'powerlaw_min' in box.parameters:
+            dn_dr, _, radii = dust_util.power_law_distribution(
+                exponent[i], 10.**r_min[i], 10.**r_max[i], 1000)
 
         ax.plot(radii, dn_dr, ls='-', lw=0.5, color='black', alpha=0.5)
 
@@ -526,7 +536,7 @@ def plot_extinction(tag: str,
     Parameters
     ----------
     tag : str
-        Database tag with the MCMC samples.
+        Database tag with the samples.
     burnin : int, None
         Number of burnin steps to exclude. All samples are used if set to ``None``. Only required
         after running MCMC with :func:`~species.analysis.fit_model.FitModel.run_mcmc`.
@@ -614,14 +624,14 @@ def plot_extinction(tag: str,
 
     sample_wavel = np.linspace(wavel_range[0], wavel_range[1], 100)
 
-    if 'dust_radius' in box.parameters and 'dust_sigma' in box.parameters and \
-            'dust_ext' in box.parameters:
+    if 'lognorm_radius' in box.parameters and 'lognorm_sigma' in box.parameters and \
+            'lognorm_ext' in box.parameters:
 
-        cross_optical, dust_radius, dust_sigma = dust_util.interpolate_dust([], [], None)
+        cross_optical, dust_radius, dust_sigma = dust_util.interp_lognorm([], [], None)
 
-        log_r_index = box.parameters.index('dust_radius')
-        sigma_index = box.parameters.index('dust_sigma')
-        ext_index = box.parameters.index('dust_ext')
+        log_r_index = box.parameters.index('lognorm_radius')
+        sigma_index = box.parameters.index('lognorm_sigma')
+        ext_index = box.parameters.index('lognorm_ext')
 
         log_r_g = samples[:, log_r_index]
         sigma_g = samples[:, sigma_index]
@@ -630,8 +640,8 @@ def plot_extinction(tag: str,
         database_path = dust_util.check_dust_database()
 
         with h5py.File(database_path, 'r') as h5_file:
-            cross_section = np.asarray(h5_file['dust/mgsio3/crystalline/cross_section'])
-            wavelength = np.asarray(h5_file['dust/mgsio3/crystalline/wavelength'])
+            cross_section = np.asarray(h5_file['dust/lognorm/mgsio3/crystalline/cross_section'])
+            wavelength = np.asarray(h5_file['dust/lognorm/mgsio3/crystalline/wavelength'])
 
         cross_interp = RegularGridInterpolator((wavelength, dust_radius, dust_sigma), cross_section)
 
@@ -644,6 +654,45 @@ def plot_extinction(tag: str,
 
             for j, item in enumerate(sample_wavel):
                 sample_cross[j] = cross_interp((item, 10.**log_r_g[i], sigma_g[i]))
+
+            sample_ext = 2.5 * np.log10(np.exp(1.)) * sample_cross * n_grains
+
+            ax.plot(sample_wavel, sample_ext, ls='-', lw=0.5, color='black', alpha=0.5)
+
+    elif 'powerlaw_min' in box.parameters and 'powerlaw_max' in box.parameters and \
+            'powerlaw_exp' in box.parameters and 'powerlaw_ext' in box.parameters:
+
+        cross_optical, dust_min, dust_max, dust_exp = dust_util.interp_powerlaw([], [], None)
+
+        r_min_index = box.parameters.index('powerlaw_min')
+        r_max_index = box.parameters.index('powerlaw_max')
+        exp_index = box.parameters.index('powerlaw_exp')
+        ext_index = box.parameters.index('powerlaw_ext')
+
+        r_min = samples[:, r_min_index]
+        r_max = samples[:, r_max_index]
+        exponent = samples[:, exp_index]
+        dust_ext = samples[:, ext_index]
+
+        database_path = dust_util.check_dust_database()
+
+        with h5py.File(database_path, 'r') as h5_file:
+            cross_section = np.asarray(h5_file['dust/powerlaw/mgsio3/crystalline/cross_section'])
+            wavelength = np.asarray(h5_file['dust/powerlaw/mgsio3/crystalline/wavelength'])
+
+        cross_interp = RegularGridInterpolator((wavelength, dust_min, dust_max, dust_exp),
+                                               cross_section)
+
+        for i in range(samples.shape[0]):
+            cross_tmp = cross_optical['Generic/Bessell.V'](
+                (10.**r_min[i], 10.**r_max[i], exponent[i]))
+
+            n_grains = dust_ext[i] / cross_tmp / 2.5 / np.log10(np.exp(1.))
+
+            sample_cross = np.zeros(sample_wavel.shape)
+
+            for j, item in enumerate(sample_wavel):
+                sample_cross[j] = cross_interp((item, 10.**r_min[i], 10.**r_max[i], exponent[i]))
 
             sample_ext = 2.5 * np.log10(np.exp(1.)) * sample_cross * n_grains
 

--- a/species/plot/plot_spectrum.py
+++ b/species/plot/plot_spectrum.py
@@ -345,7 +345,8 @@ def plot_spectrum(boxes: list,
                         if item[:4] == 'teff':
                             value = f'{param[item]:.0f}'
 
-                        elif item in ['logg', 'feh', 'co', 'fsed', 'dust_ext', 'ism_ext']:
+                        elif item in ['logg', 'feh', 'co', 'fsed', 'lognorm_ext',
+                                      'powerlaw_ext', 'ism_ext']:
                             value = f'{param[item]:.2f}'
 
                         elif item[:6] == 'radius':

--- a/species/read/read_model.py
+++ b/species/read/read_model.py
@@ -160,8 +160,8 @@ class ReadModel:
         flux = np.asarray(h5_file[f'models/{self.model}/flux'])
         flux = flux[..., self.wl_index]
 
-        self.spectrum_interp = RegularGridInterpolator(points=points,
-                                                       values=flux,
+        self.spectrum_interp = RegularGridInterpolator(points,
+                                                       flux,
                                                        method='linear',
                                                        bounds_error=False,
                                                        fill_value=np.nan)
@@ -300,19 +300,19 @@ class ReadModel:
         else:
             self.wl_points = wavel_resample
 
-        self.spectrum_interp = RegularGridInterpolator(points=points,
-                                                       values=flux_new,
+        self.spectrum_interp = RegularGridInterpolator(points,
+                                                       flux_new,
                                                        method='linear',
                                                        bounds_error=False,
                                                        fill_value=np.nan)
 
     @staticmethod
     @typechecked
-    def apply_size_dist_ext(wavelength: np.ndarray,
-                            flux: np.ndarray,
-                            radius_interp: float,
-                            sigma_interp: float,
-                            v_band_ext: float) -> np.ndarray:
+    def apply_lognorm_ext(wavelength: np.ndarray,
+                          flux: np.ndarray,
+                          radius_interp: float,
+                          sigma_interp: float,
+                          v_band_ext: float) -> np.ndarray:
         """
         Internal function for applying extinction by dust to a spectrum.
 
@@ -336,10 +336,10 @@ class ReadModel:
         database_path = dust_util.check_dust_database()
 
         with h5py.File(database_path, 'r') as h5_file:
-            dust_cross = np.asarray(h5_file['dust/mgsio3/crystalline/cross_section'])
-            dust_wavel = np.asarray(h5_file['dust/mgsio3/crystalline/wavelength'])
-            dust_radius = np.asarray(h5_file['dust/mgsio3/crystalline/radius'])
-            dust_sigma = np.asarray(h5_file['dust/mgsio3/crystalline/sigma'])
+            dust_cross = np.asarray(h5_file['dust/lognorm/mgsio3/crystalline/cross_section'])
+            dust_wavel = np.asarray(h5_file['dust/lognorm/mgsio3/crystalline/wavelength'])
+            dust_radius = np.asarray(h5_file['dust/lognorm/mgsio3/crystalline/radius_g'])
+            dust_sigma = np.asarray(h5_file['dust/lognorm/mgsio3/crystalline/sigma_g'])
 
         dust_interp = RegularGridInterpolator((dust_wavel, dust_radius, dust_sigma),
                                               dust_cross,
@@ -378,6 +378,89 @@ class ReadModel:
         sigma_full = np.full(wavelength.shape[0], sigma_interp)
 
         cross_new = dust_interp(np.column_stack((wavelength, radius_full, sigma_full)))
+
+        n_grains = v_band_ext / cross_v_band / 2.5 / np.log10(np.exp(1.))
+
+        return flux * np.exp(-cross_new*n_grains)
+
+    @staticmethod
+    @typechecked
+    def apply_powerlaw_ext(wavelength: np.ndarray,
+                           flux: np.ndarray,
+                           r_min_interp: float,
+                           r_max_interp: float,
+                           exp_interp: float,
+                           v_band_ext: float) -> np.ndarray:
+        """
+        Internal function for applying extinction by dust to a spectrum.
+
+        wavelength : np.ndarray
+            Wavelengths (um) of the spectrum.
+        flux : np.ndarray
+            Fluxes (W m-2 um-1) of the spectrum.
+        r_min_interp : float
+            Minimum radius (um) of the power-law size distribution.
+        r_max_interp : float
+            Maximum radius (um) of the power-law size distribution.
+        exp_interp : float
+            Exponent of the power-law size distribution.
+        v_band_ext : float
+            The extinction (mag) in the V band.
+
+        Returns
+        -------
+        np.ndarray
+            Fluxes (W m-2 um-1) with the extinction applied.
+        """
+
+        database_path = dust_util.check_dust_database()
+
+        with h5py.File(database_path, 'r') as h5_file:
+            dust_cross = np.asarray(h5_file['dust/powerlaw/mgsio3/crystalline/cross_section'])
+            dust_wavel = np.asarray(h5_file['dust/powerlaw/mgsio3/crystalline/wavelength'])
+            dust_r_min = np.asarray(h5_file['dust/powerlaw/mgsio3/crystalline/radius_min'])
+            dust_r_max = np.asarray(h5_file['dust/powerlaw/mgsio3/crystalline/radius_max'])
+            dust_exp = np.asarray(h5_file['dust/powerlaw/mgsio3/crystalline/exponent'])
+
+        dust_interp = RegularGridInterpolator((dust_wavel, dust_r_min, dust_r_max, dust_exp),
+                                              dust_cross,
+                                              method='linear',
+                                              bounds_error=True)
+
+        read_filt = read_filter.ReadFilter('Generic/Bessell.V')
+        filt_trans = read_filt.get_filter()
+
+        cross_phot = np.zeros((dust_r_min.shape[0], dust_r_max.shape[0], dust_exp.shape[0]))
+
+        for i in range(dust_r_min.shape[0]):
+            for j in range(dust_r_max.shape[0]):
+                for k in range(dust_exp.shape[0]):
+                    cross_interp = interp1d(dust_wavel,
+                                            dust_cross[:, i, j, k],
+                                            kind='linear',
+                                            bounds_error=True)
+
+                    cross_tmp = cross_interp(filt_trans[:, 0])
+
+                    integral1 = np.trapz(filt_trans[:, 1]*cross_tmp, filt_trans[:, 0])
+                    integral2 = np.trapz(filt_trans[:, 1], filt_trans[:, 0])
+
+                    # Filter-weighted average of the extinction cross section
+                    cross_phot[i, j, k] = integral1/integral2
+
+        cross_interp = RegularGridInterpolator((dust_r_min, dust_r_max, dust_exp),
+                                               cross_phot,
+                                               method='linear',
+                                               bounds_error=False,
+                                               fill_value=np.nan)
+
+        cross_v_band = cross_interp((10.**r_min_interp, 10.**r_max_interp, exp_interp))
+
+        r_min_full = np.full(wavelength.shape[0], 10.**r_min_interp)
+        r_max_full = np.full(wavelength.shape[0], 10.**r_max_interp)
+        exp_full = np.full(wavelength.shape[0], exp_interp)
+
+        cross_new = dust_interp(np.column_stack((wavelength, r_min_full, r_max_full, exp_full)))
 
         n_grains = v_band_ext / cross_v_band / 2.5 / np.log10(np.exp(1.))
 
@@ -456,8 +539,9 @@ class ReadModel:
 
         grid_bounds = self.get_bounds()
 
-        extra_param = ['radius', 'distance', 'mass', 'luminosity',
-                       'dust_radius', 'dust_sigma', 'dust_ext', 'ism_ext', 'ism_red']
+        extra_param = ['radius', 'distance', 'mass', 'luminosity', 'lognorm_radius',
+                       'lognorm_sigma', 'lognorm_ext', 'ism_ext', 'ism_red', 'powerlaw_min',
+                       'powerlaw_max', 'powerlaw_exp', 'powerlaw_ext']
 
         for key in self.get_parameters():
             if key not in model_param.keys():
@@ -618,14 +702,24 @@ class ReadModel:
                                    parameters=model_param,
                                    quantity=quantity)
 
-        if 'dust_radius' in model_param and 'dust_sigma' in model_param and \
-                'dust_ext' in model_param:
+        if 'lognorm_radius' in model_param and 'lognorm_sigma' in model_param and \
+                'lognorm_ext' in model_param:
 
-            model_box.flux = self.apply_size_dist_ext(model_box.wavelength,
-                                                      model_box.flux,
-                                                      model_param['dust_radius'],
-                                                      model_param['dust_sigma'],
-                                                      model_param['dust_ext'])
+            model_box.flux = self.apply_lognorm_ext(model_box.wavelength,
+                                                    model_box.flux,
+                                                    model_param['lognorm_radius'],
+                                                    model_param['lognorm_sigma'],
+                                                    model_param['lognorm_ext'])
+
+        if 'powerlaw_min' in model_param and 'powerlaw_max' in model_param and \
+                'powerlaw_exp' in model_param and 'powerlaw_ext' in model_param:
+
+            model_box.flux = self.apply_powerlaw_ext(model_box.wavelength,
+                                                     model_box.flux,
+                                                     model_param['powerlaw_min'],
+                                                     model_param['powerlaw_max'],
+                                                     model_param['powerlaw_exp'],
+                                                     model_param['powerlaw_ext'])
 
         if 'ism_ext' in model_param and 'ism_red' in model_param:
 
@@ -733,14 +827,24 @@ class ReadModel:
                                    parameters=model_param,
                                    quantity='flux')
 
-        if 'dust_radius' in model_param and 'dust_sigma' in model_param and \
-                'dust_ext' in model_param:
+        if 'lognorm_radius' in model_param and 'lognorm_sigma' in model_param and \
+                'lognorm_ext' in model_param:
 
-            model_box.flux = self.apply_size_dist_ext(model_box.wavelength,
-                                                      model_box.flux,
-                                                      model_param['dust_radius'],
-                                                      model_param['dust_sigma'],
-                                                      model_param['dust_ext'])
+            model_box.flux = self.apply_lognorm_ext(model_box.wavelength,
+                                                    model_box.flux,
+                                                    model_param['lognorm_radius'],
+                                                    model_param['lognorm_sigma'],
+                                                    model_param['lognorm_ext'])
+
+        if 'powerlaw_min' in model_param and 'powerlaw_max' in model_param and \
+                'powerlaw_exp' in model_param and 'powerlaw_ext' in model_param:
+
+            model_box.flux = self.apply_powerlaw_ext(model_box.wavelength,
+                                                     model_box.flux,
+                                                     model_param['powerlaw_min'],
+                                                     model_param['powerlaw_max'],
+                                                     model_param['powerlaw_exp'],
+                                                     model_param['powerlaw_ext'])
 
         if 'ism_ext' in model_param and 'ism_red' in model_param:
 

--- a/species/util/dust_util.py
+++ b/species/util/dust_util.py
@@ -75,7 +75,7 @@ def log_normal_distribution(radius_g: float,
         Grain radii (um).
     """
 
-    # Create radius bins across a broad range
+    # Create bins across a broad radius range to make sure that the full distribution is captured
     r_test = np.logspace(-20., 20., 1000)  # (um)
 
     # Create a size distribution for extracting the approximate minimum and maximum radius
@@ -252,7 +252,7 @@ def calc_reddening(filters_color: Tuple[str, str],
 
     filters = [extinction[0], filters_color[0], filters_color[1]]
 
-    dn_dr, r_width, radii = log_normal_distribution(radius_g, 2., 1000)
+    dn_dr, r_width, radii = log_normal_distribution(radius_g, 2., 100)
 
     c_ext = {}
 

--- a/species/util/plot_util.py
+++ b/species/util/plot_util.py
@@ -222,7 +222,7 @@ def update_labels(param: List[str]) -> List[str]:
             param[i] = rf'$\mathregular{{c}}_\mathregular{{{item[11:]}}}$ (nm)'
 
         elif item[0:9] == 'corr_len_':
-            param[i] = rf'$\mathregular{{log}}\,\ell_\mathregular{{{item[9:]}}}/\mathregular{µm}$'
+            param[i] = rf'$\mathregular{{log}}\,\ell_\mathregular{{{item[9:]}}}/\mathregular{{µm}}$'
 
         elif item[0:9] == 'corr_amp_':
             param[i] = rf'$\mathregular{{f}}_\mathregular{{{item[9:]}}}$'

--- a/species/util/plot_util.py
+++ b/species/util/plot_util.py
@@ -154,16 +154,32 @@ def update_labels(param: List[str]) -> List[str]:
         index = param.index('luminosity_ratio')
         param[index] = r'$\mathregular{log}\,\mathregular{L_1}/\mathregular{L_2}$'
 
-    if 'dust_radius' in param:
-        index = param.index('dust_radius')
+    if 'lognorm_radius' in param:
+        index = param.index('lognorm_radius')
         param[index] = r'$\mathregular{log}\,\mathregular{r_g}$'
 
-    if 'dust_sigma' in param:
-        index = param.index('dust_sigma')
+    if 'lognorm_sigma' in param:
+        index = param.index('lognorm_sigma')
         param[index] = r'$\mathregular{\sigma_g}$'
 
-    if 'dust_ext' in param:
-        index = param.index('dust_ext')
+    if 'lognorm_ext' in param:
+        index = param.index('lognorm_ext')
+        param[index] = r'$\mathregular{A_V}$'
+
+    if 'powerlaw_min' in param:
+        index = param.index('powerlaw_min')
+        param[index] = r'$\mathregular{{log}}\,\mathregular{a}_\mathregular{min}/\mathregular{µm}$'
+
+    if 'powerlaw_max' in param:
+        index = param.index('powerlaw_max')
+        param[index] = r'$\mathregular{{log}}\,\mathregular{a}_\mathregular{max}/\mathregular{µm}$'
+
+    if 'powerlaw_exp' in param:
+        index = param.index('powerlaw_exp')
+        param[index] = r'$\beta$'
+
+    if 'powerlaw_ext' in param:
+        index = param.index('powerlaw_ext')
         param[index] = r'$\mathregular{A_V}$'
 
     if 'ism_ext' in param:
@@ -206,7 +222,7 @@ def update_labels(param: List[str]) -> List[str]:
             param[i] = rf'$\mathregular{{c}}_\mathregular{{{item[11:]}}}$ (nm)'
 
         elif item[0:9] == 'corr_len_':
-            param[i] = rf'$\mathregular{{log}}\,\ell_\mathregular{{{item[9:]}}}$'
+            param[i] = rf'$\mathregular{{log}}\,\ell_\mathregular{{{item[9:]}}}/\mathregular{µm}$'
 
         elif item[0:9] == 'corr_amp_':
             param[i] = rf'$\mathregular{{f}}_\mathregular{{{item[9:]}}}$'
@@ -399,9 +415,14 @@ def quantity_unit(param: List[str],
         unit.append(None)
         label.append(r'$\mathregular{log}\,\mathregular{L}/\mathregular{L}_\mathregular{\odot}$')
 
-    if 'dust_ext' in param:
-        quantity.append('dust_ext')
-        unit.append('mag')
+    if 'lognorm_ext' in param:
+        quantity.append('lognorm_ext')
+        unit.append(None)
+        label.append(r'$\mathregular{A}_\mathregular{V}$')
+
+    if 'powerlaw_ext' in param:
+        quantity.append('powerlaw_ext')
+        unit.append(None)
         label.append(r'$\mathregular{A}_\mathregular{V}$')
 
     return quantity, unit, label

--- a/species/util/read_util.py
+++ b/species/util/read_util.py
@@ -30,12 +30,12 @@ def get_mass(model_param):
         Mass (Mjup).
     """
 
-    logg = 1e-2 * 10.**model_param['logg']  # (m s-1)
+    surface_grav = 1e-2 * 10.**model_param['logg']  # (m s-2)
 
     radius = model_param['radius']  # (Rjup)
     radius *= constants.R_JUP  # (m)
 
-    mass = logg*radius**2/constants.GRAVITY  # (kg)
+    mass = surface_grav*radius**2/constants.GRAVITY  # (kg)
     mass /= constants.M_JUP  # (Mjup)
 
     return mass


### PR DESCRIPTION
- Added support for fitting extinction parameters based on a power-law size-distribution of silicate grains. The cross-sections are interpolated from a pre-calculated grid with the maximum grain size (`powerlaw_max`), the power-law exponent (`powerlaw_exp`), and the V band extinction (`powerlaw_ext`) as free parameters. The minimum grain size is fixed to 1 nm since the results are not sensitive to the minimum grain size as long as it is much smaller than the wavelength.

- The extinction parameters for the log-normal size distribution have been changed from `dust_` to `lognorm_` without backward compatibility.

- The `add_dust` method of `Database` downloads and adds the pre-calculated cross sections.

- `ReadModel`, `plot_extinction`, `plot_size_distributions`, and `plot_util` have been updated. The `apply_lognorm_ext` method was added to `ReadModel` and `apply_size_dist_ext` was renamed to `apply_lognorm_ext`.

- Refactoring of the functions in `dust_util` and the `power_law_distribution` and `interp_powerlaw ` functions were added.