### PR TITLE
Changed the storage location of the AMES-Cond spectra

### DIFF
--- a/species/data/database.py
+++ b/species/data/database.py
@@ -342,13 +342,13 @@ class Database:
             raise ValueError(f'The {model} model is not publicly available and needs to '
                              f'be imported by setting the \'data_folder\' parameter.')
 
-        if model in ['ames-cond', 'ames-dusty', 'bt-nextgen'] and wavel_range is None:
-            raise ValueError('The \'wavel_range\' should be set for the \'{model}\' models to '
-                             'resample the original spectra on a fixed wavelength grid.')
+        if model in ['ames-dusty', 'bt-nextgen'] and wavel_range is None:
+            raise ValueError(f'The \'wavel_range\' should be set for the \'{model}\' models to '
+                             f'resample the original spectra on a fixed wavelength grid.')
 
-        if model in ['ames-cond', 'ames-dusty', 'bt-nextgen'] and spec_res is None:
-            raise ValueError('The \'spec_res\' should be set for the \'{model}\' models to '
-                             'resample the original spectra on a fixed wavelength grid.')
+        if model in ['ames-dusty', 'bt-nextgen'] and spec_res is None:
+            raise ValueError(f'The \'spec_res\' should be set for the \'{model}\' models to '
+                             f'resample the original spectra on a fixed wavelength grid.')
 
         if model == 'bt-nextgen' and teff_range is None:
             warnings.warn('The temperature range is not restricted with the \'teff_range\' '

--- a/test/test_read/test_isochrone.py
+++ b/test/test_read/test_isochrone.py
@@ -17,8 +17,7 @@ class TestIsochrone:
 
         filename = 'model.AMES-Cond-2000.M-0.0.NaCo.Vega'
 
-        url = 'https://phoenix.ens-lyon.fr/Grids/AMES-Cond/ISOCHRONES/' \
-              'model.AMES-Cond-2000.M-0.0.NaCo.Vega'
+        url = 'https://people.phys.ethz.ch/~stolkert/species/model.AMES-Cond-2000.M-0.0.NaCo.Vega'
 
         urllib.request.urlretrieve(url, filename)
 
@@ -80,10 +79,10 @@ class TestIsochrone:
         assert colormag_box.color.shape == (10, )
         assert colormag_box.magnitude.shape == (10, )
 
-        assert np.sum(colormag_box.color) == pytest.approx(2.5196748507479008,
+        assert np.sum(colormag_box.color) == pytest.approx(2.519677745822591,
                                                            rel=self.limit, abs=0.)
 
-        assert np.sum(colormag_box.magnitude) == pytest.approx(109.59753494447742,
+        assert np.sum(colormag_box.magnitude) == pytest.approx(109.59727599872247,
                                                                rel=self.limit, abs=0.)
 
         assert np.sum(colormag_box.sptype)  == pytest.approx(400., rel=self.limit, abs=0.)
@@ -101,10 +100,10 @@ class TestIsochrone:
         assert colorcolor_box.color1.shape == (10, )
         assert colorcolor_box.color2.shape == (10, )
 
-        assert np.sum(colorcolor_box.color1) == pytest.approx(2.5196748507479008,
+        assert np.sum(colorcolor_box.color1) == pytest.approx(2.519677745822591,
                                                               rel=self.limit, abs=0.)
 
-        assert np.sum(colorcolor_box.color2) == pytest.approx(3.3475160958322423,
+        assert np.sum(colorcolor_box.color2) == pytest.approx(3.3467959032673775,
                                                               rel=self.limit, abs=0.)
 
         assert np.sum(colorcolor_box.sptype) == pytest.approx(400., rel=self.limit, abs=0.)

--- a/test/test_read/test_model.py
+++ b/test/test_read/test_model.py
@@ -44,7 +44,7 @@ class TestModel:
                                          smooth=True)
 
         assert np.sum(model_box.wavelength) == pytest.approx(92.26773310928259, rel=self.limit, abs=0.)
-        assert np.sum(model_box.flux) == pytest.approx(1.634710686153774e-12, rel=self.limit, abs=0.)
+        assert np.sum(model_box.flux) == pytest.approx(1.6347074150483604e-12, rel=self.limit, abs=0.)
 
         model_box = read_model.get_model(self.model_param,
                                          spec_res=100.,
@@ -52,27 +52,27 @@ class TestModel:
                                          smooth=True)
 
         assert np.sum(model_box.wavelength) == pytest.approx(92.26773310928259, rel=self.limit, abs=0.)
-        assert np.sum(model_box.flux) == pytest.approx(650.054378183248, rel=self.limit, abs=0.)
+        assert np.sum(model_box.flux) == pytest.approx(650.0527540140317, rel=self.limit, abs=0.)
 
     def test_get_data(self):
         read_model = species.ReadModel('ames-cond', filter_name='Paranal/NACO.H')
         model_box = read_model.get_data(self.model_param)
 
         assert np.sum(model_box.wavelength) == pytest.approx(92.26773310928259, rel=self.limit, abs=0.)
-        assert np.sum(model_box.flux) == pytest.approx(1.6346965666899607e-12, rel=self.limit, abs=0.)
+        assert np.sum(model_box.flux) == pytest.approx(1.6346900092886714e-12, rel=self.limit, abs=0.)
 
     def test_get_flux(self):
         read_model = species.ReadModel('ames-cond', filter_name='Paranal/NACO.H')
         flux = read_model.get_flux(self.model_param)
 
-        assert flux[0] == pytest.approx(3.3368451740016085e-14, rel=self.limit, abs=0.)
+        assert flux[0] == pytest.approx(3.336861738800749e-14, rel=self.limit, abs=0.)
 
     def test_get_magnitude(self):
         read_model = species.ReadModel('ames-cond', filter_name='Paranal/NACO.H')
         magnitude = read_model.get_magnitude(self.model_param)
 
-        assert magnitude[0] == pytest.approx(11.357141009470052, rel=self.limit, abs=0.)
-        assert magnitude[1] == pytest.approx(11.357141009470052, rel=self.limit, abs=0.)
+        assert magnitude[0] == pytest.approx(11.357135619661243, rel=self.limit, abs=0.)
+        assert magnitude[1] == pytest.approx(11.357135619661243, rel=self.limit, abs=0.)
 
     def test_get_bounds(self):
         read_model = species.ReadModel('ames-cond', filter_name='Paranal/NACO.H')


### PR DESCRIPTION
- Changed the download location of the AMES-Cond spectra to the ETH/IPA server because https://phoenix.ens-lyon.fr/Grids is no longer available. The `add_ames_cond` function has been updated.
- The original spectra have been resampled to R=2000 from 0.5 to 40 um.
- The resampled spectra have been stored with regular units and the atmosphere parameters are included in the filename.
- AMES-Dusty and BT-NextGen, which are also downloaded from the ens-lyon.fr page, will be migrated in another PR. BT-Settl is already being downloaded from the ETH/IPA storage.