### PR TITLE
Support for filters from photon-counting detectors

### DIFF
--- a/species/read/read_filter.py
+++ b/species/read/read_filter.py
@@ -46,6 +46,16 @@ class ReadFilter:
 
         self.database = config['species']['database']
 
+        h5_file = h5py.File(self.database, 'r')
+
+        if 'filters' not in h5_file or self.filter_name not in h5_file['filters']:
+            h5_file.close()
+            species_db = database.Database()
+            species_db.add_filter(self.filter_name)
+            h5_file = h5py.File(self.database, 'r')
+
+        h5_file.close()
+
     @typechecked
     def get_filter(self) -> np.ndarray:
         """
@@ -58,12 +68,6 @@ class ReadFilter:
         """
 
         h5_file = h5py.File(self.database, 'r')
-
-        if 'filters' not in h5_file or self.filter_name not in h5_file['filters']:
-            h5_file.close()
-            species_db = database.Database()
-            species_db.add_filter(self.filter_name)
-            h5_file = h5py.File(self.database, 'r')
 
         data = np.asarray(h5_file[f'filters/{self.filter_name}'])
 
@@ -149,3 +153,20 @@ class ReadFilter:
         root2 = np.amin(diff[diff > 0.])
 
         return root2 - root1
+
+    @typechecked
+    def detector_type(self) -> str:
+        """
+        Function for returning the detector type.
+
+        Returns
+        -------
+        str
+            Detector type ('energy' or 'photon').
+        """
+
+        with h5py.File(self.database, 'r') as h5_file:
+            dset = h5_file[f'filters/{self.filter_name}']
+            det_type = dset.attrs['det_type']
+
+        return det_type

--- a/test/test_analysis/test_photometry.py
+++ b/test/test_analysis/test_photometry.py
@@ -1,7 +1,9 @@
 import os
 import shutil
+import urllib.request
 
 import pytest
+import numpy as np
 
 import species
 from species.util import test_util
@@ -12,9 +14,13 @@ class TestPhotometry:
     def setup_class(self):
         self.limit = 1e-8
 
+        url = 'http://irtfweb.ifa.hawaii.edu/~spex/IRTF_Spectral_Library/Data/plnt_Jupiter.txt'
+        urllib.request.urlretrieve(url, 'plnt_Jupiter.txt')
+
     def teardown_class(self):
         os.remove('species_database.hdf5')
         os.remove('species_config.ini')
+        os.remove('plnt_Jupiter.txt')
         shutil.rmtree('data/')
 
     def test_species_init(self):
@@ -37,3 +43,77 @@ class TestPhotometry:
 
         assert app_mag[0] == pytest.approx(3.729995213054507, rel=self.limit, abs=0.)
         assert abs_mag[0] == pytest.approx(0.23514519137441336, rel=self.limit, abs=0.)
+
+    def test_spectrum_to_flux(self):
+        jup_wavel, jup_flux, jup_err = np.loadtxt('plnt_Jupiter.txt', unpack=True)
+
+        synphot = species.SyntheticPhotometry('MKO/NSFCam.J')
+
+        phot_flux, phot_error = synphot.spectrum_to_flux(jup_wavel,
+                                                         jup_flux,
+                                                         error=jup_err,
+                                                         threshold=None)
+
+        assert phot_flux == pytest.approx(1.802998152236653e-09, rel=self.limit, abs=0.)
+
+        # The error is estimated with Monte Carlo sampling
+        assert phot_error == pytest.approx(8.8e-14, rel=0., abs=2e-14)
+
+    def test_spectrum_to_flux_no_error(self):
+        jup_wavel, jup_flux, _ = np.loadtxt('plnt_Jupiter.txt', unpack=True)
+
+        synphot = species.SyntheticPhotometry('MKO/NSFCam.J')
+
+        phot_flux, phot_error = synphot.spectrum_to_flux(jup_wavel,
+                                                         jup_flux,
+                                                         error=None,
+                                                         threshold=None)
+
+        assert phot_flux == pytest.approx(1.802998152236653e-09, rel=self.limit, abs=0.)
+        assert phot_error is None
+
+    def test_spectrum_to_flux_threshold(self):
+        jup_wavel, jup_flux, _ = np.loadtxt('plnt_Jupiter.txt', unpack=True)
+
+        synphot = species.SyntheticPhotometry('MKO/NSFCam.J')
+
+        phot_flux, phot_error = synphot.spectrum_to_flux(jup_wavel,
+                                                         jup_flux,
+                                                         error=None,
+                                                         threshold=0.05)
+
+        assert phot_flux == pytest.approx(1.802998152236653e-09, rel=self.limit, abs=0.)
+        assert phot_error is None
+
+    def test_spectrum_to_flux_photon_detector(self):
+        jup_wavel, jup_flux, jup_err = np.loadtxt('plnt_Jupiter.txt', unpack=True)
+
+        synphot = species.SyntheticPhotometry('Keck/NIRC2.J')
+
+        phot_flux, phot_error = synphot.spectrum_to_flux(jup_wavel,
+                                                         jup_flux,
+                                                         error=jup_err,
+                                                         threshold=None)
+
+        assert phot_flux == pytest.approx(1.8139884828774647e-09, rel=self.limit, abs=0.)
+
+        # The error is estimated with Monte Carlo sampling
+        assert phot_error == pytest.approx(8.4e-14, rel=0., abs=2e-14)
+
+    def test_spectrum_to_magnitude(self):
+        jup_wavel, jup_flux, jup_err = np.loadtxt('plnt_Jupiter.txt', unpack=True)
+
+        synphot = species.SyntheticPhotometry('MKO/NSFCam.J')
+
+        app_mag, abs_mag = synphot.spectrum_to_magnitude(jup_wavel,
+                                                         jup_flux,
+                                                         error=jup_err,
+                                                         distance=(1., 0.01),
+                                                         threshold=None)
+
+        assert app_mag[0] == pytest.approx(0.5900070089410099, rel=self.limit, abs=0.)
+        assert abs_mag[0] == pytest.approx(5.59000700894101, rel=self.limit, abs=0.)
+
+        # The error is estimated with Monte Carlo sampling
+        assert app_mag[1] == pytest.approx(5.368048545366946e-05, rel=0., abs=1e-5)
+        assert abs_mag[1] == pytest.approx(0.021714790446227043, rel=0., abs=1e-2)

--- a/test/test_read/test_filter.py
+++ b/test/test_read/test_filter.py
@@ -35,6 +35,25 @@ class TestFilter:
         assert filter_profile.shape == (970, 2)
         assert np.sum(filter_profile) == pytest.approx(2089.2432, rel=1e-6, abs=0.)
 
+    def test_detector_type(self):
+        read_filter = species.ReadFilter('MKO/NSFCam.H')
+        det_type = read_filter.detector_type()
+
+        assert det_type == 'energy'
+
+    def test_get_filter_photon_counter(self):
+        read_filter = species.ReadFilter('Keck/NIRC2.J')
+        filter_profile = read_filter.get_filter()
+
+        assert filter_profile.shape == (1054, 2)
+        assert np.sum(filter_profile) == pytest.approx(2038.0486, rel=1e-6, abs=0.)
+
+    def test_detector_type_photon(self):
+        read_filter = species.ReadFilter('Keck/NIRC2.J')
+        det_type = read_filter.detector_type()
+
+        assert det_type == 'photon'
+
     def test_interpolate_filter(self):
         read_filter = species.ReadFilter('MKO/NSFCam.H')
         interp_filter = read_filter.interpolate_filter()


### PR DESCRIPTION
- Added support for filters from photon-counting detectors. The detector type determines if an additional wavelength factor is included in the integral for the synthetic photometry.
- For filters that are automatically fetched from the SVO webpage, the detector type is read from the data.
- For filters that are manually added with `add_filter`, the detector type needs to be set with the `detector_type` parameter (default: `'photon'`).
- The detector type is stored in the database as the `det_type` attribute with the filter profile.
- The `SyntheticPhotometry` checks the detector type when calculating average fluxes.
- The `download_filter` function has been updated.
- Added the `detector_type` method to `ReadFilter` which returns the detector type.
- Added unit tests for the `spectrum_to_flux` and `spectrum_to_magnitude` methods of `SyntheticPhotometry`.
- Minor improvement in the wavelength selection for the Monte Carlo errors that are sampled in `spectrum_to_flux`.