### PR TITLE
Resampled the BT-NextGen spectra and changed their download location

### DIFF
--- a/species/data/btnextgen.py
+++ b/species/data/btnextgen.py
@@ -11,7 +11,6 @@ from typing import Optional, Tuple
 import h5py
 import spectres
 import numpy as np
-import pandas as pd
 
 from typeguard import typechecked
 
@@ -21,11 +20,12 @@ from species.util import data_util, read_util
 @typechecked
 def add_btnextgen(input_path: str,
                   database: h5py._hl.files.File,
-                  wavel_range: Tuple[float, float],
+                  wavel_range: Optional[Tuple[float, float]] = None,
                   teff_range: Optional[Tuple[float, float]] = None,
-                  spec_res: float = 1000.) -> None:
+                  spec_res: float = None) -> None:
     """
-    Function for adding the BT-NextGen atmospheric models to the database.
+    Function for adding the BT-NextGen atmospheric models to the database. The original spectra
+    have been resampled to a spectral resolution of R = 2000 from 0.1 to 50 um.
 
     Parameters
     ----------
@@ -33,12 +33,14 @@ def add_btnextgen(input_path: str,
         Folder where the data is located.
     database : h5py._hl.files.File
         Database.
-    wavel_range : tuple(float, float)
-        Wavelength range (um).
+    wavel_range : tuple(float, float), None
+        Wavelength range (um). The full wavelength range (0.1-50 um) is stored if set to ``None``.
+        Only used in combination with ``spec_res``.
     teff_range : tuple(float, float), None
-        Effective temperature range (K). All data is selected if set to ``None``.
-    spec_res : float
-        Spectral resolution.
+        Effective temperature range (K). All available temperatures are stored if set to ``None``.
+    spec_res : float, None
+        Spectral resolution. The data is stored with the spectral resolution of the input spectra
+        (R = 2000) if set to ``None``. Only used in combination with ``wavel_range``.
 
     Returns
     -------
@@ -49,109 +51,86 @@ def add_btnextgen(input_path: str,
     if not os.path.exists(input_path):
         os.makedirs(input_path)
 
+    input_file = 'bt-nextgen.tgz'
+    url = 'https://people.phys.ethz.ch/~ipa/tstolker/bt-nextgen.tgz'
+
     data_folder = os.path.join(input_path, 'bt-nextgen/')
+    data_file = os.path.join(input_path, input_file)
 
-    files = ['BT-NextGen_M-0.0_a+0.0_hot.tar',
-             'BT-NextGen_M+0.3_a+0.0_hot.tar',
-             'BT-NextGen_M+0.5_a+0.0_hot.tar']
+    if not os.path.exists(data_folder):
+        os.makedirs(data_folder)
 
-    urls = ['https://phoenix.ens-lyon.fr/Grids/BT-NextGen/SPECTRA/BT-NextGen_M-0.0_a+0.0_hot.tar',
-            'https://phoenix.ens-lyon.fr/Grids/BT-NextGen/SPECTRA/BT-NextGen_M+0.3_a+0.0_hot.tar',
-            'https://phoenix.ens-lyon.fr/Grids/BT-NextGen/SPECTRA/BT-NextGen_M+0.5_a+0.0_hot.tar']
-
-    labels = ['[Fe/H]=0.0 (5.9 GB)',
-              '[Fe/H]=0.3 (6.2 GB)',
-              '[Fe/H]=0.5 (6.4 GB)']
-
-    for i, item in enumerate(files):
-        data_file = os.path.join(input_path, item)
-
-        if not os.path.isfile(data_file):
-            print(f'Downloading BT-NextGen model spectra {labels[i]}...', end='', flush=True)
-            urllib.request.urlretrieve(urls[i], data_file)
-            print(' [DONE]')
-
-        print(f'Unpacking BT-NextGen model spectra {labels[i]}...', end='', flush=True)
-        tar = tarfile.open(data_file)
-        tar.extractall(data_folder)
-        tar.close()
+    if not os.path.isfile(data_file):
+        print('Downloading BT-NextGen model spectra (368 MB)...', end='', flush=True)
+        urllib.request.urlretrieve(url, data_file)
         print(' [DONE]')
+
+    print('Unpacking BT-NextGen model spectra (368 MB)...', end='', flush=True)
+    tar = tarfile.open(data_file)
+    tar.extractall(data_folder)
+    tar.close()
+    print(' [DONE]')
 
     teff = []
     logg = []
     feh = []
     flux = []
 
-    wavelength = read_util.create_wavelengths(wavel_range, spec_res)
+    if wavel_range is not None and spec_res is not None:
+        wavelength = read_util.create_wavelengths(wavel_range, spec_res)
+    else:
+        wavelength = None
 
-    for _, _, file_list in os.walk(data_folder):
-        for filename in sorted(file_list):
+    for _, _, files in os.walk(data_folder):
+        for filename in files:
+            if filename[:11] == 'bt-nextgen_':
+                file_split = filename.split('_')
 
-            if filename.startswith('lte') and filename.endswith('.7.bz2'):
-                teff_val = float(filename[3:6])*100.
-                logg_val = float(filename[7:9])
-                feh_val = float(filename[11:14])
+                teff_val = float(file_split[2])
+                logg_val = float(file_split[4])
+                feh_val = float(file_split[6])
 
                 if teff_range is not None:
                     if teff_val < teff_range[0] or teff_val > teff_range[1]:
                         continue
 
                 print_message = f'Adding BT-NextGen model spectra... {filename}'
-                print(f'\r{print_message:<72}', end='')
+                print(f'\r{print_message:<82}', end='')
 
-                dataf = pd.pandas.read_csv(data_folder+filename,
-                                           usecols=[0, 1],
-                                           names=['wavelength', 'flux'],
-                                           header=None,
-                                           dtype={'wavelength': str, 'flux': str},
-                                           delim_whitespace=True,
-                                           compression='bz2')
-
-                dataf['wavelength'] = dataf['wavelength'].str.replace('D', 'E')
-                dataf['flux'] = dataf['flux'].str.replace('D', 'E')
-
-                dataf = dataf.apply(pd.to_numeric)
-                data = dataf.values
-
-                # (Angstrom) -> (um)
-                data_wavel = data[:, 0]*1e-4
-
-                # See https://phoenix.ens-lyon.fr/Grids/FORMAT
-                data_flux = 10.**(data[:, 1]-8.)  # (erg s-1 cm-2 Angstrom-1)
-
-                # (erg s-1 cm-2 Angstrom-1) -> (W m-2 um-1)
-                data_flux = data_flux*1e-7*1e4*1e4
-
-                data = np.stack([data_wavel, data_flux], axis=1)
-
-                index_sort = np.argsort(data[:, 0])
-                data = data[index_sort, :]
-
-                if np.all(np.diff(data[:, 0]) < 0):
-                    raise ValueError('The wavelengths are not all sorted by increasing value.')
+                data_wavel, data_flux = np.loadtxt(os.path.join(data_folder, filename), unpack=True)
 
                 teff.append(teff_val)
                 logg.append(logg_val)
                 feh.append(feh_val)
 
-                flux_resample = spectres.spectres(wavelength,
-                                                  data[:, 0],
-                                                  data[:, 1],
-                                                  spec_errs=None,
-                                                  fill=np.nan,
-                                                  verbose=False)
+                if wavel_range is None or spec_res is None:
+                    if wavelength is None:
+                        wavelength = np.copy(data_wavel)  # (um)
 
-                if np.isnan(np.sum(flux_resample)):
-                    raise ValueError(f'Resampling is only possible if the new wavelength '
-                                     f'range ({wavelength[0]} - {wavelength[-1]} um) falls '
-                                     f'sufficiently far within the wavelength range '
-                                     f'({data[0, 0]} - {data_wavel[-1, 0]} um) of the input '
-                                     f'spectra.')
+                    if np.all(np.diff(wavelength) < 0):
+                        raise ValueError('The wavelengths are not all sorted by increasing value.')
 
-                flux.append(flux_resample)  # (W m-2 um-1)
+                    flux.append(data_flux)  # (W m-2 um-1)
+
+                else:
+                    flux_resample = spectres.spectres(wavelength,
+                                                      data_wavel,
+                                                      data_flux,
+                                                      spec_errs=None,
+                                                      fill=np.nan,
+                                                      verbose=False)
+
+                    if np.isnan(np.sum(flux_resample)):
+                        raise ValueError(f'Resampling is only possible if the new wavelength '
+                                         f'range ({wavelength[0]} - {wavelength[-1]} um) falls '
+                                         f'sufficiently far within the wavelength range '
+                                         f'({data_wavel[0]} - {data_wavel[-1]} um) of the input '
+                                         f'spectra.')
+
+                    flux.append(flux_resample)  # (W m-2 um-1)
 
     print_message = 'Adding BT-NextGen model spectra... [DONE]'
-    print(f'\r{print_message:<72}')
+    print(f'\r{print_message:<82}')
 
     data_sorted = data_util.sort_data(np.asarray(teff),
                                       np.asarray(logg),
@@ -161,4 +140,7 @@ def add_btnextgen(input_path: str,
                                       wavelength,
                                       np.asarray(flux))
 
-    data_util.write_data('bt-nextgen', ['teff', 'logg', 'feh'], database, data_sorted)
+    data_util.write_data('bt-nextgen',
+                         ['teff', 'logg', 'feh'],
+                         database,
+                         data_sorted)

--- a/species/data/database.py
+++ b/species/data/database.py
@@ -351,18 +351,18 @@ class Database:
             raise ValueError(f'The {model} model is not publicly available and needs to '
                              f'be imported by setting the \'data_folder\' parameter.')
 
-        if model in ['bt-nextgen'] and wavel_range is None:
-            raise ValueError(f'The \'wavel_range\' should be set for the \'{model}\' models to '
-                             f'resample the original spectra on a fixed wavelength grid.')
+        # if model in ['bt-nextgen'] and wavel_range is None:
+        #     raise ValueError(f'The \'wavel_range\' should be set for the \'{model}\' models to '
+        #                      f'resample the original spectra on a fixed wavelength grid.')
 
-        if model in ['bt-nextgen'] and spec_res is None:
-            raise ValueError(f'The \'spec_res\' should be set for the \'{model}\' models to '
-                             f'resample the original spectra on a fixed wavelength grid.')
+        # if model in ['bt-nextgen'] and spec_res is None:
+        #     raise ValueError(f'The \'spec_res\' should be set for the \'{model}\' models to '
+        #                      f'resample the original spectra on a fixed wavelength grid.')
 
-        if model == 'bt-nextgen' and teff_range is None:
-            warnings.warn('The temperature range is not restricted with the \'teff_range\' '
-                          'parameter. Therefore, adding the BT-Settl or BT-NextGen spectra '
-                          'will be very slow.')
+        # if model == 'bt-nextgen' and teff_range is None:
+        #     warnings.warn('The temperature range is not restricted with the \'teff_range\' '
+        #                   'parameter. Therefore, adding the BT-Settl or BT-NextGen spectra '
+        #                   'will be very slow.')
 
         h5_file = h5py.File(self.database, 'a')
 


### PR DESCRIPTION
The BT-NextGen spectra have been resampled to R=2000 from 0.1 to 50 micron, and their download location has been changed since https://phoenix.ens-lyon.fr/Grids/ is offline. Only spectra with Teff < 30000 K and 3 <= log(g) <= 5 have been used, with 3 grid point for [Fe/H]. With the resampling, the TAR file is only 368 MB, so it is also much faster to download and process. The `add_btnextgen` function had been updated.