### PR TITLE
Support for different formats of the histogram titles of plot_posterior

### DIFF
--- a/species/util/plot_util.py
+++ b/species/util/plot_util.py
@@ -226,7 +226,7 @@ def update_labels(param: List[str]) -> List[str]:
             param[i] = rf'$\mathregular{{c}}_\mathregular{{{item[11:]}}}$ (nm)'
 
         elif item[0:9] == 'corr_len_':
-            param[i] = rf'$\mathregular{{log}}\,\ell_\mathregular{{{item[9:]}}}/\mathregular{{µm}}$'
+            param[i] = rf'$\mathregular{{log}}\,\ell_\mathregular{{{item[9:]}}}$'
 
         elif item[0:9] == 'corr_amp_':
             param[i] = rf'$\mathregular{{f}}_\mathregular{{{item[9:]}}}$'


### PR DESCRIPTION
The `title_fmt` parameter of `plot_posterior` has been changed with backward compatibility. The format of the titles above the histograms in the posterior plots can be set for each parameter individually by providing a list with formats instead of a single string.