### PR TITLE
Use only last axis for parameter selection in samples

### DIFF
--- a/species/plot/plot_mcmc.py
+++ b/species/plot/plot_mcmc.py
@@ -296,12 +296,12 @@ def plot_posterior(tag: str,
 
     # Use only last axis for parameter dimensions
     for i in range(ndim):
-        if np.amin(samples[:, :, i]) == np.amax(samples[:, :, i]):
+        if np.amin(samples[..., i]) == np.amax(samples[..., i]):
             index_del.append(i)
         else:
             index_sel.append(i)
 
-    samples = samples[:, :, index_sel]
+    samples = samples[..., index_sel]
 
     for i in range(len(index_del)-1, -1, -1):
         del labels[index_del[i]]

--- a/species/plot/plot_mcmc.py
+++ b/species/plot/plot_mcmc.py
@@ -294,13 +294,14 @@ def plot_posterior(tag: str,
     index_sel = []
     index_del = []
 
+    # Use only last axis for parameter dimensions
     for i in range(ndim):
-        if np.amin(samples[:, i]) == np.amax(samples[:, i]):
+        if np.amin(samples[:, :, i]) == np.amax(samples[:, :, i]):
             index_del.append(i)
         else:
             index_sel.append(i)
 
-    samples = samples[:, index_sel]
+    samples = samples[:, :, index_sel]
 
     for i in range(len(index_del)-1, -1, -1):
         del labels[index_del[i]]


### PR DESCRIPTION
This should fix #31. I replaced `:` with `...` to ensure that only the last axis (parameters) is affected by selection. This prevents the 3D `run_mcmc` samples to be truncated to 4-5 samples per walkers. It should not affected `run_multinest` which will behave as before.