### PR TITLE
Improved sampling of the log-normal distribution

### DIFF
--- a/species/data/atmo.py
+++ b/species/data/atmo.py
@@ -25,7 +25,7 @@ def add_atmo(input_path: str,
              spec_res: Optional[float]) -> None:
     """
     Function for adding the ATMO 2020 atmospheric models to the database. The spectra have been
-    calculated with equilibrium chemistry and solar metallicity in the Teff range from 200 to 
+    calculated with equilibrium chemistry and solar metallicity in the Teff range from 200 to
     3000 K. The spectra have been downloaded from the Theoretical spectra web server
     (http://svo2.cab.inta-csic.es/svo/theory/newov2/index.php?models=atmo2020_ceq) and resampled
     to a spectral resolution of 5000 from 0.3 to 100 um.

--- a/species/read/read_spectrum.py
+++ b/species/read/read_spectrum.py
@@ -141,7 +141,7 @@ class ReadSpectrum:
                 if 'name' in attrs:
                     if isinstance(dset.attrs['name'], str):
                         list_name.append(dset.attrs['name'])
-                    else:                        
+                    else:
                         list_name.append(dset.attrs['name'].decode('utf-8'))
                 else:
                     list_name.append('')

--- a/species/util/read_util.py
+++ b/species/util/read_util.py
@@ -143,8 +143,9 @@ def update_spectra(objectbox: box.ObjectBox,
 
             if f'error_{key}' in model_param:
                 error = 10.**model_param[f'error_{key}']
+                log_msg = f'Inflating the error of {key} (W m-2 um-1): {error:.2e}...'
 
-                print(f'Inflating the error of {key} (W m-2 um-1): {error:.2e}...', end='', flush=True)
+                print(log_msg, end='', flush=True)
                 spec_tmp[:, 2] += error
                 print(' [DONE]')
 


### PR DESCRIPTION
Improved sampling of the log-normal distribution in `dust_util.log_normal_distribution`. The `interval` method is used to calculate the grain radius interval that contains 99.999% of the distribution.