### PR TITLE
Improved error inflation, new log-normal cross sections, and some minor things

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 *species*
 =========
 
-**s**\ pectral and **p**\ hotometric **e**\ xamination **c**\ ode for **i**\ nvestigating **e**\ xoplanet and **s**\ ubstellar atmospheres
+**spe**\ctral **c**\ haracterization and **i**\ nference for **e**\ xoplanet **s**\ cience
 
 .. image:: https://badge.fury.io/py/species.svg
     :target: https://badge.fury.io/py/species
@@ -27,7 +27,7 @@
 .. image:: https://img.shields.io/badge/arXiv-1912.13316-orange.svg?style=flat
     :target: https://arxiv.org/abs/1912.13316
 
-*species* is a toolkit for atmospheric characterization of exoplanets and brown dwarfs. It provides a coherent framework for spectral and photometric analysis which builds on publicly-available data from various resources such as spectral and photometric libraries, atmospheric models, and evolutionary tracks. There are tools available for grid retrievals with Bayesian inference, color-magnitude diagrams, spectral and photometric calibration, and synthetic photometry. The package has been released on `PyPI <https://pypi.org/project/species/>`_ and is actively developed and maintained on Github.
+*species* is a toolkit for atmospheric characterization of directly imaged exoplanets and brown dwarfs. It provides a coherent framework for spectral and photometric analysis which builds on publicly-available data and models from various resources. There are tools available for grid and free atmospheric retrievals with Bayesian inference, color-magnitude and color-color diagrams, spectral and photometric calibration, and synthetic photometry. The package is has been released on `PyPI <https://pypi.org/project/species/>`_ and is actively developed and maintained on Github.
 
 Documentation
 -------------
@@ -42,11 +42,11 @@ Please cite `Stolker et al. (2020) <https://ui.adsabs.harvard.edu/abs/2020A%26A.
 Contributing
 ------------
 
-Contributions are welcome, please consider forking the repository and creating a pull request. Bug reports can be provided by creating an `issue <https://github.com/tomasstolker/species/issues>`_ on the Github page.
+Contributions are welcome so please consider forking the repository and creating a pull request. Bug reports can be provided by creating an `issue <https://github.com/tomasstolker/species/issues>`_ on the Github page.
 
 License
 -------
 
-Copyright 2018-2020 Tomas Stolker
+Copyright 2018-2021 Tomas Stolker
 
 *species* is distributed under the MIT License. See the LICENSE file for the terms and conditions.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,7 +20,7 @@ sys.path.insert(0, os.path.abspath('../'))
 # -- Project information -----------------------------------------------------
 
 project = 'species'
-copyright = '2018-2020, Tomas Stolker'
+copyright = '2018-2021, Tomas Stolker'
 author = 'Tomas Stolker'
 
 # The short X.Y version

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -21,14 +21,14 @@ In this case the database is stored in the working folder and an absolute path p
          >>> import os
          >>> os.getcwd()
 
-The workflow with *species* is now initiated with :class:`~species.core.setup.SpeciesInit`:
+The workflow with *species* can now be initiated with the :class:`~species.core.setup.SpeciesInit` class:
 
 .. code-block:: python
 
    >>> import species
    >>> species.SpeciesInit()
 
-A configuration file with default values is automatically created when `species` is initiated and the configuration file is not present in the working folder.
+Alternatively, a configuration file with default values is automatically created when `species` is initiated and the configuration file is not present in the working folder.
 
 .. tip::
    The same `data_folder` can be used in multiple configuration files. In this way, the data is only downloaded once and easily reused by a new instance of :class:`~species.core.setup.SpeciesInit`. Also the HDF5 database can be reused by simply including the same `database` in the configuration file.

--- a/species/analysis/fit_model.py
+++ b/species/analysis/fit_model.py
@@ -805,6 +805,26 @@ class FitModel:
                     self.modelpar.append(f'error_{item}')
                     self.bounds[f'error_{item}'] = (bounds[item][1][0], bounds[item][1][1])
 
+                    if self.bounds[f'error_{item}'][0] < 0.:
+                        warnings.warn(f'The lower bound of \'error_{item}\' is smaller than 0. The '
+                                      f'error inflation should be given relative to the model fluxes '
+                                      f'so the boundaries are typically between 0 and 1.')
+
+                    if self.bounds[f'error_{item}'][1] < 0.:
+                        warnings.warn(f'The upper bound of \'error_{item}\' is smaller than 0. The '
+                                      f'error inflation should be given relative to the model fluxes '
+                                      f'so the boundaries are typically between 0 and 1.')
+
+                    if self.bounds[f'error_{item}'][0] > 1.:
+                        warnings.warn(f'The lower bound of \'error_{item}\' is larger than 1. The '
+                                      f'error inflation should be given relative to the model fluxes '
+                                      f'so the boundaries are typically between 0 and 1.')
+
+                    if self.bounds[f'error_{item}'][1] > 1.:
+                        warnings.warn(f'The upper bound of \'error_{item}\' is larger than 1. The '
+                                      f'error inflation should be given relative to the model fluxes '
+                                      f'so the boundaries are typically between 0 and 1.')
+
                 if item in self.bounds:
                     del self.bounds[item]
 
@@ -955,8 +975,8 @@ class FitModel:
                 guess[f'scaling_{item}'] = guess[item][0]
 
             if f'error_{item}' in self.bounds:
-                sigma[f'error_{item}'] = 0.1  # (dex)
-                guess[f'error_{item}'] = guess[item][1]  # (dex)
+                sigma[f'error_{item}'] = 0.1
+                guess[f'error_{item}'] = guess[item][1]
 
             if item in guess:
                 del guess[item]

--- a/species/data/companions.py
+++ b/species/data/companions.py
@@ -150,21 +150,21 @@ def get_data() -> Dict[str, Dict[str, Union[Tuple[float, float],
                                      'Paranal/SPHERE.IRDIS_B_Ks': (13.51, 0.20)}},  # Kennedy et al. 2020
 
             'GQ Lup B': {'distance': (151.82, 1.10),
-                         'app_mag': {'HST/WFPC2-PC.F606W': (19.19, 0.07),  # Marois et al. 2006
-                                     'HST/WFPC2-PC.F814W': (17.67, 0.05),  # Marois et al. 2006
-                                     'HST/NICMOS2.F171M': (13.84, 0.13),  # Marois et al. 2006
-                                     'HST/NICMOS2.F190N': (14.08, 0.20),  # Marois et al. 2006
-                                     'HST/NICMOS2.F215N': (13.40, 0.15),  # Marois et al. 2006
-                                     'Magellan/VisAO.ip': (18.89, 0.24),  # Wu et al. 20017
-                                     'Magellan/VisAO.zp': (16.40, 0.10),  # Wu et al. 20017
-                                     'Magellan/VisAO.Ys': (15.88, 0.10),  # Wu et al. 20017
+                         'app_mag': {'HST/WFPC2-PC.F606W': (19.19, 0.07),  # Marois et al. 2007
+                                     'HST/WFPC2-PC.F814W': (17.67, 0.05),  # Marois et al. 2007
+                                     'HST/NICMOS2.F171M': (13.84, 0.13),  # Marois et al. 2007
+                                     'HST/NICMOS2.F190N': (14.08, 0.20),  # Marois et al. 2007
+                                     'HST/NICMOS2.F215N': (13.40, 0.15),  # Marois et al. 2007
+                                     'Magellan/VisAO.ip': (18.89, 0.24),  # Wu et al. 2017
+                                     'Magellan/VisAO.zp': (16.40, 0.10),  # Wu et al. 2017
+                                     'Magellan/VisAO.Ys': (15.88, 0.10),  # Wu et al. 2017
                                      'Paranal/NACO.Ks': [(13.474, 0.031),  # Ginski et al. 2014
                                                          (13.386, 0.032),  # Ginski et al. 2014
                                                          (13.496, 0.050),  # Ginski et al. 2014
-                                                         (13.501, 0.028), ],  # Ginski et al. 2014
-                                     'Subaru/CIAO.CH4s': (13.76, 0.26),  # Marois et al. 2006
-                                     'Subaru/CIAO.K': (13.37, 0.12),  # Marois et al. 2006
-                                     'Subaru/CIAO.Lp': (12.44, 0.22)}},  # Marois et al. 2006
+                                                         (13.501, 0.028)],  # Ginski et al. 2014
+                                     'Subaru/CIAO.CH4s': (13.76, 0.26),  # Marois et al. 2007
+                                     'Subaru/CIAO.K': (13.37, 0.12),  # Marois et al. 2007
+                                     'Subaru/CIAO.Lp': (12.44, 0.22)}},  # Marois et al. 2007
 
             'PZ Tel B': {'distance': (47.13, 0.13),
                          'app_mag': {'Paranal/SPHERE.ZIMPOL_R_PRIM': (17.84, 0.31),  # Maire et al. 2015

--- a/species/data/database.py
+++ b/species/data/database.py
@@ -539,7 +539,7 @@ class Database:
                                            Tuple[str,
                                                  Optional[str],
                                                  Optional[float]]]] = None,
-                   deredden: Dict[str, float] = None) -> None:
+                   deredden: Union[Dict[str, float], float] = None) -> None:
         """
         Function for adding the photometric and/or spectroscopic data of an object to the database.
 
@@ -573,7 +573,7 @@ class Database:
             50.)}``. No covariance data is stored if set to None, for example, ``{'SPHERE':
             ('spectrum.dat', None, 50.)}``. The ``spectrum`` parameter is ignored if set to None.
             For GRAVITY data, the same FITS file can be provided as spectrum and covariance matrix.
-        deredden : dict, None
+        deredden : dict, float, None
             Dictionary with ``spectrum`` and ``app_mag`` names that will de dereddened with the
             provided A_V. For example, ``deredden={'SPHERE': 1.5, 'Keck/NIRC2.J': 1.5}`` will
             deredden the provided spectrum named 'SPHERE' and the Keck/NIRC2 J-band photometry with
@@ -630,12 +630,16 @@ class Database:
 
         if app_mag is not None:
             for mag_item in app_mag:
-                if mag_item in deredden:
+                if isinstance(deredden, float) or mag_item in deredden:
                     read_filt = read_filter.ReadFilter(mag_item)
                     filter_profile = read_filt.get_filter()
 
-                    ext_mag = dust_util.ism_extinction(deredden[mag_item], 3.1,
-                                                       filter_profile[:, 0])
+                    if isinstance(deredden, float):
+                        ext_mag = dust_util.ism_extinction(deredden, 3.1, filter_profile[:, 0])
+
+                    else:
+                        ext_mag = dust_util.ism_extinction(deredden[mag_item], 3.1,
+                                                           filter_profile[:, 0])
 
                     synphot = photometry.SyntheticPhotometry(mag_item)
 
@@ -719,7 +723,10 @@ class Database:
                     print(f'      - Flux (W m-2 um-1) = {flux[mag_item]:.2e} +/- '
                           f'{error[mag_item]:.2e}')
 
-                    if mag_item in deredden:
+                    if isinstance(deredden, float):
+                        print(f'      - Dereddening A_V: {deredden}')
+
+                    elif mag_item in deredden:
                         print(f'      - Dereddening A_V: {deredden[mag_item]}')
 
                     data = np.asarray([app_mag[mag_item][0],
@@ -747,7 +754,10 @@ class Database:
                         mag_list.append(app_mag_item[0])
                         mag_err_list.append(app_mag_item[1])
 
-                        if mag_item in deredden:
+                        if isinstance(deredden, float):
+                            print(f'      - Dereddening A_V: {deredden}')
+
+                        elif mag_item in deredden:
                             print(f'      - Dereddening A_V: {deredden[mag_item]}')
 
                     data = np.asarray([mag_list,
@@ -763,7 +773,7 @@ class Database:
 
         if flux_density is not None:
             for flux_item in flux_density:
-                if flux_item in deredden:
+                if isinstance(deredden, float) or flux_item in deredden:
                     warnings.warn(f'The deredden parameter is not supported by flux_density. '
                                   f'Please use app_mag instead or contact Tomas Stolker and ask '
                                   f'if the flux_density support can be added. Ignoring the '
@@ -845,7 +855,11 @@ class Database:
                     print('   - Spectrum:')
                     read_spec[key] = data
 
-                if key in deredden:
+                if isinstance(deredden, float):
+                    ext_mag = dust_util.ism_extinction(deredden, 3.1, read_spec[key][:, 0])
+                    read_spec[key][:, 1] *= 10.**(0.4*ext_mag)
+
+                elif key in deredden:
                     ext_mag = dust_util.ism_extinction(deredden[key], 3.1, read_spec[key][:, 0])
                     read_spec[key][:, 1] *= 10.**(0.4*ext_mag)
 
@@ -860,7 +874,10 @@ class Database:
                 print(f'      - Mean flux (W m-2 um-1): {np.mean(flux):.2e}')
                 print(f'      - Mean error (W m-2 um-1): {np.mean(error):.2e}')
 
-                if key in deredden:
+                if isinstance(deredden, float):
+                    print(f'      - Dereddening A_V: {deredden}')
+
+                elif key in deredden:
                     print(f'      - Dereddening A_V: {deredden[key]}')
 
             # Read covariance matrix

--- a/species/plot/plot_color.py
+++ b/species/plot/plot_color.py
@@ -52,7 +52,7 @@ def plot_color_magnitude(boxes: list,
     objects : list(tuple(str, str, str, str), ),
               list(tuple(str, str, str, str, dict, dict), ), None
         Tuple with individual objects. The objects require a tuple with their database tag, the two
-        filter names for the color, and the filter names for the absolute magnitude. Optionally, a
+        filter names for the color, and the filter name for the absolute magnitude. Optionally, a
         dictionary with keyword arguments can be provided for the object's marker and label,
         respectively. For example, ``{'marker': 'o', 'ms': 10}`` for the marker and
         ``{'ha': 'left', 'va': 'bottom', 'xytext': (5, 5)})`` for the label. Not used if set to

--- a/species/plot/plot_spectrum.py
+++ b/species/plot/plot_spectrum.py
@@ -230,7 +230,7 @@ def plot_spectrum(boxes: list,
         ax1.set_xlabel('Wavelength (µm)', fontsize=13)
 
     if filters is not None:
-        ax2.set_ylabel('Transmission', fontsize=13)
+        ax2.set_ylabel('T$_\lambda$', fontsize=13)
 
     if residuals is not None:
         if quantity == 'flux density':

--- a/species/util/plot_util.py
+++ b/species/util/plot_util.py
@@ -266,15 +266,15 @@ def update_labels(param: List[str]) -> List[str]:
 
     if 'log_powerlaw_a' in param:
         index = param.index('log_powerlaw_a')
-        param[index] = r'$\mathregular{log}\,a$'
+        param[index] = r'$a_\mathregular{powerlaw}$'
 
     if 'log_powerlaw_b' in param:
         index = param.index('log_powerlaw_b')
-        param[index] = r'$\mathregular{log}\,b$'
+        param[index] = r'$b_\mathregular{powerlaw}$'
 
     if 'log_powerlaw_c' in param:
         index = param.index('log_powerlaw_c')
-        param[index] = r'$\mathregular{log}\,c$'
+        param[index] = r'$c_\mathregular{powerlaw}$'
 
     return param
 


### PR DESCRIPTION
- Improved approach for fitting the error inflation of spectra in `FitModel`. Instead of fitting a constant, the free parameter is a scaling relative to the model fluxes (see Piette & Madhusudhan 2020). The use of the error inflation parameter has not changed but in this case typically requires a `bound` value between 0 and 1. Both `run_multinest` and `run_mcmc` have been updated.
- The optional `model` parameter has been added to `update_spectra` since the error inflation requires calculating the model spectrum.
- Bug fix with the use of fixed parameters in `FitModel` since the calibration and extinction parameters were not fixed.
- The `deredden` parameter in `add_object` can also be a float (instead of dictionary), in which case the same dereddening is applied to all input data.
- When fitting an atmosphere + disk, the `disk_teff` and `disk_radius` parameters are included in the luminosity calculation of `plot_posterior`.
- A new grid of dust cross sections with a log-normal distribution has been calculated with a small improvement in the sampling of the distribution and in this case also ignoring grains smaller than 1 nm. The `plot_size_distributions` function has been updated accordingly. The new cross sections are downloaded and added to the `Database` with `add_dust`.
- Updated README, documentation, and code comments.