### PR TITLE
Tools for empirical spectral analysis

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,5 +9,5 @@ build:
 python:
    version: 3.8
    install:
-      - requirements: requirements.txt
       - requirements: docs/requirements.txt
+      - requirements: requirements.txt

--- a/README.rst
+++ b/README.rst
@@ -24,7 +24,7 @@
 .. image:: https://img.shields.io/github/license/tomasstolker/species
    :target: https://github.com/tomasstolker/species/blob/master/LICENSE
 
-*species* is a toolkit for atmospheric characterization of directly imaged exoplanets. It provides a coherent framework for spectral and photometric analysis which builds on publicly-available data and models from various resources. There are tools available for both grid retrievals and free retrievals with Bayesian inference, color-magnitude and color-color diagrams, spectral and photometric calibration, and synthetic photometry. The package has been released on `PyPI <https://pypi.org/project/species/>`_ and is actively developed and maintained on Github.
+*species* is a toolkit for atmospheric characterization of directly imaged exoplanets. It provides a coherent framework for spectral and photometric analysis which builds on publicly-available data and models from various resources. There are tools available for both grid retrievals and free retrievals with Bayesian inference, color-magnitude and color-color diagrams, empirical spectral analysis, spectral and photometric calibration, and synthetic photometry. The package has been released on `PyPI <https://pypi.org/project/species/>`_ and is actively developed and maintained on Github.
 
 Documentation
 -------------

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -13,7 +13,7 @@ Supported data
 
 The *species* toolkit benefits from publicly available data resources such as photometric and spectral libraries, atmospheric model spectra, evolutionary tracks, and photometry of directly imaged planets and brown dwarfs. The relevant data are automatically downloaded and added to the HDF5 database, which acts as the central data storage for a workflow. All data are stored in a fixed format such that the analysis and plotting tools can easily access and manipulate the data.
 
-The following data are currently supported:
+The following data and models are currently supported:
 
 **Atmospheric model spectra**
 
@@ -32,6 +32,7 @@ The following data are currently supported:
 
 - `IRTF Spectral Library <http://irtfweb.ifa.hawaii.edu/~spex/IRTF_Spectral_Library/>`_
 - `SpeX Prism Spectral Libraries <http://pono.ucsd.edu/~adam/browndwarfs/spexprism/index_old.html>`_
+- `SDSS spectra by Kesseli et al. (2017) <https://ui.adsabs.harvard.edu/abs/2017ApJS..230...16K/abstract>`_
 
 **Photometric libraries**
 
@@ -70,3 +71,4 @@ After adding the relevant data to the database, the user can take advantage of t
 - Creating color-color diagrams (see :class:`~species.read.read_color.ReadColorColor` and :class:`~species.plot.plot_color.plot_color_color`).
 - Computing synthetic fluxes from isochrones and model spectra (see :class:`~species.read.read_isochrone.ReadIsochrone`)
 - Flux calibration of photometric and spectroscopic data (see :class:`~species.read.read_calibration.ReadCalibration`, :class:`~species.analysis.fit_model.FitModel`, and :class:`~species.analysis.fit_spectrum.FitSpectrum`).
+- Empirical comparison of spectra to infer the spectral type (see :class:`~species.analysis.empirical.CompareSpectra`).

--- a/species/__init__.py
+++ b/species/__init__.py
@@ -1,3 +1,5 @@
+from species.analysis.empirical import CompareSpectra
+
 from species.analysis.fit_model import FitModel
 
 from species.analysis.fit_spectrum import FitSpectrum
@@ -34,6 +36,9 @@ from species.core.setup import SpeciesInit
 from species.data.companions import get_data
 
 from species.data.database import Database
+
+from species.plot.plot_empirical import plot_statistic, \
+                                        plot_empirical_spectra
 
 from species.plot.plot_color import plot_color_magnitude, \
                                     plot_color_color

--- a/species/analysis/empirical.py
+++ b/species/analysis/empirical.py
@@ -1,0 +1,256 @@
+"""
+Module with functionalities for empirical spectral analysis.
+"""
+
+import configparser
+import os
+
+from typing import List, Optional, Tuple, Union
+
+import h5py
+import numpy as np
+
+from scipy.interpolate import interp1d
+from typeguard import typechecked
+
+from species.core import constants
+from species.data import database
+from species.read import read_object
+from species.util import dust_util, read_util
+
+
+class CompareSpectra:
+    """
+    Class for comparing a spectrum of an object with the spectra of a library.
+    """
+
+    @typechecked
+    def __init__(self,
+                 object_name: str,
+                 spec_name: str,
+                 spec_library: str) -> None:
+        """
+        Parameters
+        ----------
+        object_name : str
+            Object name as stored in the database with
+            :func:`~species.data.database.Database.add_object` or
+            :func:`~species.data.database.Database.add_companion`.
+        spec_name : str
+            Name of the spectrum that is stored at the object data of ``object_name``.
+        spec_library : str
+            Name of the spectral library ('irtf', 'spex', or 'kesseli+2017).
+
+        Returns
+        -------
+        NoneType
+            None
+        """
+
+        self.object_name = object_name
+        self.spec_name = spec_name
+        self.spec_library = spec_library
+
+        self.object = read_object.ReadObject(object_name)
+
+        config_file = os.path.join(os.getcwd(), 'species_config.ini')
+
+        config = configparser.ConfigParser()
+        config.read_file(open(config_file))
+
+        self.database = config['species']['database']
+
+    @typechecked
+    def spectral_type(self,
+                      tag: str,
+                      wavel_range: Optional[Tuple[Optional[float], Optional[float]]] = None,
+                      sptypes: Optional[List[str]] = None,
+                      av_ext: Optional[Union[List[float], np.array]] = None,
+                      rad_vel: Optional[Union[List[float], np.array]] = None) -> None:
+        """
+        Method for finding the best fitting empirical spectra from a selected library by
+        calculating for each spectrum the goodness-of-fit statistic from Cushing et al. (2008).
+
+        Parameters
+        ----------
+        tag : str
+            Database tag where for each spectrum from the spectral library the best-fit parameters
+            will be stored. So when testing a range of values for ``av_ext`` and ``rad_vel``, only
+            the parameters that minimize the goodness-of-fit statistic will be stored.
+        wavel_range : tuple(float, float), None
+            Wavelength range (um) that is used for the empirical comparison.
+        sptypes : list(str), None
+            List with spectral types to compare with. The list should only contains types, for
+            example ``sptypes=['M', 'L']``. All available spectral types in the ``spec_library``
+            are compared with if set to ``None``.
+        av_ext : list(float), np.array, None
+            List of A_V extinctions for which the goodness-of-fit statistic is tested. The
+            extinction is calculated with the empirical relation from Cardelli et al. (1989).
+        rad_vel : list(float), np.array, None
+            List of radial velocities (km s-1) for which the goodness-of-fit statistic is tested.
+
+        Returns
+        -------
+        NoneType
+            None
+        """
+
+        w_i = 1.
+
+        if av_ext is None:
+            av_ext = [0.]
+
+        if rad_vel is None:
+            rad_vel = [0.]
+
+        h5_file = h5py.File(self.database, 'r')
+
+        try:
+            h5_file[f'spectra/{self.spec_library}']
+
+        except KeyError:
+            h5_file.close()
+            species_db = database.Database()
+            species_db.add_spectrum(self.spec_library)
+            h5_file = h5py.File(self.database, 'r')
+
+        obj_spec = self.object.get_spectrum()[self.spec_name][0]
+        obj_res = self.object.get_spectrum()[self.spec_name][3]
+
+        name_list = []
+        spt_list = []
+        gk_list = []
+        ck_list = []
+        av_list = []
+        rv_list = []
+
+        print_message = ''
+
+        for i, item in enumerate(h5_file[f'spectra/{self.spec_library}']):
+            dset = h5_file[f'spectra/{self.spec_library}/{item}']
+            item_sptype = dset.attrs['sptype'].decode('utf-8')
+
+            if item_sptype == 'None':
+                continue
+
+            if sptypes is None or item_sptype[0] in sptypes:
+                spectrum = np.asarray(dset)
+
+                if wavel_range is not None:
+                    if wavel_range[0] is None:
+                        indices = np.where((spectrum[:, 0] < wavel_range[1]))[0]
+
+                    elif wavel_range[1] is None:
+                        indices = np.where((spectrum[:, 0] > wavel_range[0]))[0]
+
+                    else:
+                        indices = np.where((spectrum[:, 0] > wavel_range[0]) &
+                                           (spectrum[:, 0] < wavel_range[1]))[0]
+
+                    if len(indices) == 0:
+                        raise ValueError('The selected wavelength range does not cover any '
+                                         'wavelength points of the input spectrum. Please '
+                                         'use a broader range as argument of \'wavel_range\'.')
+
+                    spectrum = spectrum[indices, ]
+
+                empty_message = len(print_message)*' '
+                print(f'\r{empty_message}', end='')
+
+                print_message = f'Processing spectra... {item}'
+                print(f'\r{print_message}', end='')
+
+                for av_item in av_ext:
+                    for rv_item in rad_vel:
+                        ism_ext = dust_util.ism_extinction(av_item, 3.1, spectrum[:, 0])
+                        flux_scaling = 10.**(-0.4*ism_ext)
+
+                        wavel_shifted = spectrum[:, 0] + spectrum[:, 0] * 1e3*rv_item / constants.LIGHT
+
+                        flux_smooth = read_util.smooth_spectrum(wavel_shifted,
+                                                                spectrum[:, 1]*flux_scaling,
+                                                                spec_res=obj_res,
+                                                                force_smooth=True)
+
+                        interp_spec = interp1d(spectrum[:, 0],
+                                               flux_smooth,
+                                               kind='linear',
+                                               fill_value='extrapolate')
+
+                        indices = np.where((obj_spec[:, 0] > np.amin(spectrum[:, 0])) &
+                                           (obj_spec[:, 0] < np.amax(spectrum[:, 0])))[0]
+
+                        flux_resample = interp_spec(obj_spec[indices, 0])
+
+                        c_numer = w_i*obj_spec[indices, 1]*flux_resample/obj_spec[indices, 2]**2
+                        c_denom = w_i*flux_resample**2/obj_spec[indices, 2]**2
+
+                        c_k = np.sum(c_numer) / np.sum(c_denom)
+
+                        chi_sq = (obj_spec[indices, 1] - c_k*flux_resample) / obj_spec[indices, 2]
+                        g_k = np.sum(w_i * chi_sq**2)
+
+                        name_list.append(item)
+                        spt_list.append(item_sptype)
+                        gk_list.append(g_k)
+                        ck_list.append(c_k)
+                        av_list.append(av_item)
+                        rv_list.append(rv_item)
+
+        empty_message = len(print_message)*' '
+        print(f'\r{empty_message}', end='')
+
+        print('\rProcessing spectra... [DONE]')
+
+        h5_file.close()
+
+        name_list = np.asarray(name_list)
+        spt_list = np.asarray(spt_list)
+        gk_list = np.asarray(gk_list)
+        ck_list = np.asarray(ck_list)
+        av_list = np.asarray(av_list)
+        rv_list = np.asarray(rv_list)
+
+        sort_index = np.argsort(gk_list)
+
+        name_list = name_list[sort_index]
+        spt_list = spt_list[sort_index]
+        gk_list = gk_list[sort_index]
+        ck_list = ck_list[sort_index]
+        av_list = av_list[sort_index]
+        rv_list = rv_list[sort_index]
+
+        name_select = []
+        spt_select = []
+        gk_select = []
+        ck_select = []
+        av_select = []
+        rv_select = []
+
+        for i, item in enumerate(name_list):
+            if item not in name_select:
+                name_select.append(item)
+                spt_select.append(spt_list[i])
+                gk_select.append(gk_list[i])
+                ck_select.append(ck_list[i])
+                av_select.append(av_list[i])
+                rv_select.append(rv_list[i])
+
+        print('Best-fitting spectra:')
+
+        for i in range(10):
+            print(f'   - G = {gk_select[i]:.2e} -> {name_select[i]}, {spt_select[i]}, '
+                  f'A_V = {av_select[i]:.2f}, RV = {rv_select[i]:.0f} km/s')
+
+        species_db = database.Database()
+
+        species_db.add_empirical(tag=tag,
+                                 names=name_select,
+                                 sptypes=spt_select,
+                                 goodness_of_fit=gk_select,
+                                 flux_scaling=ck_select,
+                                 av_ext=av_select,
+                                 rad_vel=rv_select,
+                                 object_name=self.object_name,
+                                 spec_name=self.spec_name,
+                                 spec_library=self.spec_library)

--- a/species/data/irtf.py
+++ b/species/data/irtf.py
@@ -31,7 +31,7 @@ def add_irtf(input_path: str,
         Path of the data folder.
     database : h5py._hl.files.File
         Database.
-    sptypes : list(str, ), None
+    sptypes : list(str), None
         List with the spectral types ('F', 'G', 'K', 'M', 'L', 'T'). All spectral types are
         included if set to ``None``.
 
@@ -110,6 +110,8 @@ def add_irtf(input_path: str,
 
     database.create_group('spectra/irtf')
 
+    print_message = ''
+
     for item in sptypes:
         for root, _, files in os.walk(data_folder[item]):
 
@@ -130,8 +132,11 @@ def add_irtf(input_path: str,
                     spt_split = sptype.split()
 
                     if item in ['L', 'T'] or spt_split[1][0] == 'V':
+                        empty_message = len(print_message) * ' '
+                        print(f'\r{empty_message}', end='')
+
                         print_message = f'Adding IRTF Spectral Library... {name}'
-                        print(f'\r{print_message:<70}', end='')
+                        print(f'\r{print_message}', end='')
 
                         simbad_id = query_util.get_simbad(name)
 
@@ -161,7 +166,10 @@ def add_irtf(input_path: str,
                         dset.attrs['distance'] = distance[0]
                         dset.attrs['distance_error'] = distance[1]
 
+    empty_message = len(print_message) * ' '
+    print(f'\r{empty_message}', end='')
+
     print_message = 'Adding IRTF Spectral Library... [DONE]'
-    print(f'\r{print_message:<70}')
+    print(f'\r{print_message}')
 
     database.close()

--- a/species/data/kesseli2017.py
+++ b/species/data/kesseli2017.py
@@ -1,0 +1,99 @@
+"""
+Module for adding O5 through L3 SDSS stellar spectra from Kesseli et al. (2017) to the database.
+"""
+
+import os
+import shutil
+import tarfile
+import urllib.request
+
+import h5py
+import numpy as np
+
+from astropy.io import fits
+from typeguard import typechecked
+
+
+@typechecked
+def add_kesseli2017(input_path: str,
+                    database: h5py._hl.files.File) -> None:
+    """
+    Function for adding the SDSS stellar spectra from Kesseli et al. (2017) to the database.
+
+    Parameters
+    ----------
+    input_path : str
+        Path of the data folder.
+    database : h5py._hl.files.File
+        The HDF5 database.
+
+    Returns
+    -------
+    NoneType
+        None
+    """
+
+    data_url = 'https://cdsarc.unistra.fr/viz-bin/nph-Cat/tar.gz?J/ApJS/230/16'
+    data_file = os.path.join(input_path, 'J_ApJS_230_16.tar.gz')
+    data_folder = os.path.join(input_path, 'kesseli+2017/')
+
+    if not os.path.exists(data_folder):
+        os.makedirs(data_folder)
+
+    if not os.path.isfile(data_file):
+        print('Downloading SDSS spectra from Kesseli et al. 2017 (25 MB)...', end='', flush=True)
+        urllib.request.urlretrieve(data_url, data_file)
+        print(' [DONE]')
+
+    if os.path.exists(data_folder):
+        shutil.rmtree(data_folder)
+
+    print('Unpacking SDSS spectra from Kesseli et al. 2017 (25 MB)...', end='', flush=True)
+    tar = tarfile.open(data_file)
+    tar.extractall(data_folder)
+    tar.close()
+    print(' [DONE]')
+
+    database.create_group('spectra/kesseli+2017')
+
+    fits_folder = os.path.join(data_folder, 'fits')
+
+    print_message = ''
+
+    for _, _, files in os.walk(fits_folder):
+        for _, filename in enumerate(files):
+            if filename[-4:] != '.fits':
+                with fits.open(os.path.join(fits_folder, filename)) as hdu_list:
+                    data = hdu_list[1].data
+
+                    wavelength = 1e-4*10.**data['LogLam']  # (um)
+                    flux = data['Flux']  # Normalized units
+                    error = data['PropErr']  # Normalized units
+
+                    name = filename[:-5].replace('_', ' ')
+
+                    file_split = filename.split('_')
+                    file_split = file_split[0].split('.')
+
+                    sptype = file_split[0]
+
+                    spdata = np.column_stack([wavelength, flux, error])
+
+                    empty_message = len(print_message) * ' '
+                    print(f'\r{empty_message}', end='')
+
+                    print_message = f'Adding SDSS spectra from Kesseli et al. 2017... {name}'
+                    print(f'\r{print_message}', end='')
+
+                    dset = database.create_dataset(f'spectra/kesseli+2017/{name}', data=spdata)
+
+                    dset.attrs['name'] = str(name).encode()
+                    dset.attrs['sptype'] = str(sptype).encode()
+
+    empty_message = len(print_message) * ' '
+    print(f'\r{empty_message}', end='')
+
+    print_message = 'Adding SDSS spectra from Kesseli et al. 2017... [DONE]'
+    print(f'\r{print_message}')
+
+    database.close()

--- a/species/data/leggett.py
+++ b/species/data/leggett.py
@@ -154,10 +154,10 @@ def add_leggett(input_path,
     dset = database.create_dataset(group+'/sptype', (np.size(sptype), ), dtype=dtype)
     dset[...] = sptype
 
-    none_data = np.repeat('None', np.size(name))
+    flag = np.repeat('null', np.size(name))
 
-    dset = database.create_dataset(group+'/flag', (np.size(none_data), ), dtype=dtype)
-    dset[...] = none_data
+    dset = database.create_dataset(group+'/flag', (np.size(flag), ), dtype=dtype)
+    dset[...] = flag
 
     database.create_dataset(group+'/distance', data=distance)
     database.create_dataset(group+'/distance_error', data=distance_error)

--- a/species/data/leggett.py
+++ b/species/data/leggett.py
@@ -65,8 +65,10 @@ def add_leggett(input_path,
 
     name = np.asarray(dataframe['Name'])
 
+    # Near-infrared spectral type
     sptype = np.asarray(dataframe['Type'])
     sptype = data_util.update_sptype(sptype)
+    sptype = np.asarray(sptype)
 
     mag_y = np.asarray(dataframe['Y'])
     mag_j = np.asarray(dataframe['J'])
@@ -152,10 +154,10 @@ def add_leggett(input_path,
     dset = database.create_dataset(group+'/sptype', (np.size(sptype), ), dtype=dtype)
     dset[...] = sptype
 
-    flag = np.repeat('null', np.size(name))
+    none_data = np.repeat('None', np.size(name))
 
-    dset = database.create_dataset(group+'/flag', (np.size(flag), ), dtype=dtype)
-    dset[...] = flag
+    dset = database.create_dataset(group+'/flag', (np.size(none_data), ), dtype=dtype)
+    dset[...] = none_data
 
     database.create_dataset(group+'/distance', data=distance)
     database.create_dataset(group+'/distance_error', data=distance_error)

--- a/species/data/vlm_plx.py
+++ b/species/data/vlm_plx.py
@@ -59,15 +59,15 @@ def add_vlm_plx(input_path,
     name = phot_data['NAME']
     name = np.core.defchararray.strip(name)
 
-    sptype = phot_data['ISPTSTR']
+    sptype = phot_data['OSPTSTR']
     sptype = np.core.defchararray.strip(sptype)
 
-    sptype_op = phot_data['OSPTSTR']
-    sptype_op = np.core.defchararray.strip(sptype_op)
+    sptype_nir = phot_data['ISPTSTR']
+    sptype_nir = np.core.defchararray.strip(sptype_nir)
 
     for i, item in enumerate(sptype):
-        if item == 'null':
-            sptype[i] = sptype_op[i]
+        if item == 'None':
+            sptype[i] = sptype_nir[i]
 
     flag = phot_data['FLAG']
     flag = np.core.defchararray.strip(flag)

--- a/species/data/vlm_plx.py
+++ b/species/data/vlm_plx.py
@@ -66,7 +66,7 @@ def add_vlm_plx(input_path,
     sptype_nir = np.core.defchararray.strip(sptype_nir)
 
     for i, item in enumerate(sptype):
-        if item == 'None':
+        if item == 'null':
             sptype[i] = sptype_nir[i]
 
     flag = phot_data['FLAG']

--- a/species/plot/plot_empirical.py
+++ b/species/plot/plot_empirical.py
@@ -1,0 +1,292 @@
+"""
+Module with a function for plotting results from the empirical spectral analysis.
+"""
+
+import configparser
+import os
+
+from typing import Optional, Tuple
+
+import h5py
+import numpy as np
+import matplotlib as mpl
+import matplotlib.pyplot as plt
+
+from matplotlib.ticker import AutoMinorLocator
+from scipy.interpolate import interp1d
+from typeguard import typechecked
+
+from species.core import constants
+from species.read import read_object
+from species.util import dust_util, read_util
+
+
+@typechecked
+def plot_statistic(tag: str,
+                   xlim: Optional[Tuple[float, float]] = None,
+                   ylim: Optional[Tuple[float, float]] = None,
+                   title: Optional[str] = None,
+                   offset: Optional[Tuple[float, float]] = None,
+                   figsize: Optional[Tuple[float, float]] = (4., 2.5),
+                   output: str = 'statistic.pdf'):
+    """
+    Function for plotting the goodness-of-fit statistic of the empirical spectral comparison.
+
+    Parameters
+    ----------
+    tag : str
+        Database tag where the results from the empirical comparison with
+        :class:`~species.analysis.empirical.CompareSpectra.spectral_type` are stored.
+    xlim : tuple(float, float)
+        Limits of the spectral type axis in numbers (i.e. 0=M0, 5=M5, 10=L0, etc.).
+    ylim : tuple(float, float)
+        Limits of the goodness-of-fit axis.
+    title : str
+        Plot title.
+    offset : tuple(float, float)
+        Offset for the label of the x- and y-axis.
+    figsize : tuple(float, float)
+        Figure size.
+    output : str
+        Output filename.
+
+    Returns
+    -------
+    NoneType
+        None
+    """
+
+    print(f'Plotting goodness-of-fit statistic: {output}...', end='')
+
+    config_file = os.path.join(os.getcwd(), 'species_config.ini')
+
+    config = configparser.ConfigParser()
+    config.read_file(open(config_file))
+
+    db_path = config['species']['database']
+
+    h5_file = h5py.File(db_path, 'r')
+
+    dset = h5_file[f'results/empirical/{tag}/names']
+
+    names = np.array(dset)
+    sptypes = np.array(h5_file[f'results/empirical/{tag}/sptypes'])
+    g_fit = np.array(h5_file[f'results/empirical/{tag}/goodness_of_fit'])
+
+    mpl.rcParams['font.serif'] = ['Bitstream Vera Serif']
+    mpl.rcParams['font.family'] = 'serif'
+
+    plt.rc('axes', edgecolor='black', linewidth=2.2)
+    plt.rcParams['axes.axisbelow'] = False
+
+    plt.figure(1, figsize=figsize)
+    gridsp = mpl.gridspec.GridSpec(1, 1)
+    gridsp.update(wspace=0, hspace=0, left=0, right=1, bottom=0, top=1)
+
+    ax = plt.subplot(gridsp[0, 0])
+
+    ax.tick_params(axis='both', which='major', colors='black', labelcolor='black',
+                   direction='in', width=1, length=5, labelsize=12, top=True,
+                   bottom=True, left=True, right=True)
+
+    ax.tick_params(axis='both', which='minor', colors='black', labelcolor='black',
+                   direction='in', width=1, length=3, labelsize=12, top=True,
+                   bottom=True, left=True, right=True)
+
+    ax.xaxis.set_minor_locator(AutoMinorLocator(5))
+    ax.yaxis.set_minor_locator(AutoMinorLocator(5))
+
+    ax.set_xlabel('Spectral type', fontsize=13)
+    ax.set_ylabel('G', fontsize=13)
+
+    if offset is not None:
+        ax.get_xaxis().set_label_coords(0.5, offset[0])
+        ax.get_yaxis().set_label_coords(offset[1], 0.5)
+
+    else:
+        ax.get_xaxis().set_label_coords(0.5, -0.1)
+        ax.get_yaxis().set_label_coords(-0.1, 0.5)
+
+    if title is not None:
+        ax.set_title(title, y=1.02, fontsize=13)
+
+    ax.set_xticks(np.linspace(0., 30., 7, endpoint=True))
+    ax.set_xticklabels(['M0', 'M5', 'L0', 'L5', 'T0', 'T5', 'Y0'])
+
+    if xlim is None:
+        ax.set_xlim(0., 30.)
+    else:
+        ax.set_xlim(xlim[0], xlim[1])
+
+    if ylim is not None:
+        ax.set_ylim(ylim[0], ylim[1])
+
+    sptype_num = np.zeros(names.shape[0])
+
+    for i, item in enumerate(sptypes):
+        for j in range(10):
+            if item == f'M{j}':
+                sptype_num[i] = float(j)
+
+            elif item == f'L{j}':
+                sptype_num[i] = float(10+j)
+
+            elif item == f'T{j}':
+                sptype_num[i] = float(20+j)
+
+    ax.plot(sptype_num, g_fit, 's', ms=3., mew=0.5, color='lightgray', markeredgecolor='darkgray')
+
+    plt.savefig(os.getcwd()+'/'+output, bbox_inches='tight')
+    plt.clf()
+    plt.close()
+
+    h5_file.close()
+
+    print(' [DONE]')
+
+
+@typechecked
+def plot_empirical_spectra(tag: str,
+                           n_spectra: int,
+                           xlim: Optional[Tuple[float, float]] = None,
+                           ylim: Optional[Tuple[float, float]] = None,
+                           title: Optional[str] = None,
+                           offset: Optional[Tuple[float, float]] = None,
+                           figsize: Optional[Tuple[float, float]] = (4., 2.5),
+                           output: str = 'empirical.pdf'):
+    """
+    Function for plotting the results from the empirical spectrum comparison.
+
+    Parameters
+    ----------
+    tag : str
+        Database tag where the results from the empirical comparison with
+        :class:`~species.analysis.empirical.CompareSpectra.spectral_type` are stored.
+    n_spectra : int
+        The number of spectra with the lowest goodness-of-fit statistic that will be plotted in
+        comparison with the data.
+    xlim : tuple(float, float)
+        Limits of the spectral type axis.
+    ylim : tuple(float, float)
+        Limits of the goodness-of-fit axis.
+    title : str
+        Plot title.
+    offset : tuple(float, float)
+        Offset for the label of the x- and y-axis.
+    figsize : tuple(float, float)
+        Figure size.
+    output : str
+        Output filename.
+
+    Returns
+    -------
+    NoneType
+        None
+    """
+
+    print(f'Plotting empirical spectra comparison: {output}...', end='')
+
+    config_file = os.path.join(os.getcwd(), 'species_config.ini')
+
+    config = configparser.ConfigParser()
+    config.read_file(open(config_file))
+
+    db_path = config['species']['database']
+
+    h5_file = h5py.File(db_path, 'r')
+
+    dset = h5_file[f'results/empirical/{tag}/names']
+
+    object_name = dset.attrs['object_name']
+    spec_name = dset.attrs['spec_name']
+    spec_library = dset.attrs['spec_library']
+
+    names = np.array(dset)
+    flux_scaling = np.array(h5_file[f'results/empirical/{tag}/flux_scaling'])
+    av_ext = np.array(h5_file[f'results/empirical/{tag}/av_ext'])
+
+    rad_vel = np.array(h5_file[f'results/empirical/{tag}/rad_vel'])
+    rad_vel *= 1e3  # (m s-1)
+
+    mpl.rcParams['font.serif'] = ['Bitstream Vera Serif']
+    mpl.rcParams['font.family'] = 'serif'
+
+    plt.rc('axes', edgecolor='black', linewidth=2.2)
+    plt.rcParams['axes.axisbelow'] = False
+
+    plt.figure(1, figsize=figsize)
+    gridsp = mpl.gridspec.GridSpec(1, 1)
+    gridsp.update(wspace=0, hspace=0, left=0, right=1, bottom=0, top=1)
+
+    ax = plt.subplot(gridsp[0, 0])
+
+    ax.tick_params(axis='both', which='major', colors='black', labelcolor='black',
+                   direction='in', width=1, length=5, labelsize=12, top=True,
+                   bottom=True, left=True, right=True)
+
+    ax.tick_params(axis='both', which='minor', colors='black', labelcolor='black',
+                   direction='in', width=1, length=3, labelsize=12, top=True,
+                   bottom=True, left=True, right=True)
+
+    ax.xaxis.set_minor_locator(AutoMinorLocator(5))
+    ax.yaxis.set_minor_locator(AutoMinorLocator(5))
+
+    ax.set_xlabel('Wavelength (µm)', fontsize=13)
+    ax.set_ylabel(r'$\mathregular{F}_\lambda$ (W m$^{-2}$ µm$^{-1}$)', fontsize=11)
+
+    if xlim is not None:
+        ax.set_xlim(xlim[0], xlim[1])
+
+    if ylim is not None:
+        ax.set_ylim(ylim[0], ylim[1])
+
+    if offset is not None:
+        ax.get_xaxis().set_label_coords(0.5, offset[0])
+        ax.get_yaxis().set_label_coords(offset[1], 0.5)
+
+    else:
+        ax.get_xaxis().set_label_coords(0.5, -0.1)
+        ax.get_yaxis().set_label_coords(-0.1, 0.5)
+
+    if title is not None:
+        ax.set_title(title, y=1.02, fontsize=13)
+
+    read_obj = read_object.ReadObject(object_name)
+
+    obj_spec = read_obj.get_spectrum()[spec_name][0]
+    obj_res = read_obj.get_spectrum()[spec_name][3]
+
+    for i in range(n_spectra):
+        spectrum = np.asarray(h5_file[f'spectra/{spec_library}/{names[i]}'])
+
+        ism_ext = dust_util.ism_extinction(av_ext[i], 3.1, spectrum[:, 0])
+        ext_scaling = 10.**(-0.4*ism_ext)
+
+        wavel_shifted = spectrum[:, 0] + spectrum[:, 0] * rad_vel[i] / constants.LIGHT
+
+        flux_smooth = read_util.smooth_spectrum(wavel_shifted,
+                                                spectrum[:, 1]*ext_scaling,
+                                                spec_res=obj_res,
+                                                force_smooth=True)
+
+        interp_spec = interp1d(spectrum[:, 0],
+                               flux_smooth,
+                               fill_value='extrapolate')
+
+        indices = np.where((obj_spec[:, 0] > np.amin(spectrum[:, 0])) &
+                           (obj_spec[:, 0] < np.amax(spectrum[:, 0])))[0]
+
+        flux_resample = interp_spec(obj_spec[indices, 0])
+
+        ax.plot(obj_spec[indices, 0], flux_scaling[i]*flux_resample, color='gray', lw=0.3,
+                alpha=0.5, zorder=1)
+
+    ax.plot(obj_spec[:, 0], obj_spec[:, 1], '-', lw=0.6, color='black')
+
+    plt.savefig(os.getcwd()+'/'+output, bbox_inches='tight')
+    plt.clf()
+    plt.close()
+
+    h5_file.close()
+
+    print(' [DONE]')

--- a/species/read/read_spectrum.py
+++ b/species/read/read_spectrum.py
@@ -2,8 +2,8 @@
 Module with reading functionalities for spectral libraries.
 """
 
-import os
 import configparser
+import os
 
 from typing import List
 
@@ -70,6 +70,9 @@ class ReadSpectrum:
         sptypes : list(str), None
             Spectral types to select from a library. The spectral types should be indicated with
             two characters (e.g. 'M5', 'L2', 'T3'). All spectra are selected if set to ``None``.
+            For each object in the ``spec_library``, the requested ``sptypes`` are first compared
+            with the optical spectral type and, if not available, secondly the near-infrared
+            spectral type.
         exclude_nan : bool
             Exclude wavelength points for which the flux is NaN.
 

--- a/species/util/data_util.py
+++ b/species/util/data_util.py
@@ -2,19 +2,21 @@
 Utility functions for data processing.
 """
 
-from typing import Optional, List
+from typing import List, Optional
 
 import h5py
 import numpy as np
 
+from scipy.interpolate import griddata
 from typeguard import typechecked
 
-from scipy.interpolate import griddata
 
-
-def update_sptype(sptypes):
+@typechecked
+def update_sptype(sptypes: np.ndarray) -> List[str]:
     """
-    Function to update a list with spectral types to two characters (e.g., M8, L3, or T1).
+    Function to update a list with spectral types to two characters (e.g., M8, L3, or T1). The
+    spectral to is set to NaN in case the first character is not recognized or the second character
+    is not a numerical value.
 
     Parameters
     ----------
@@ -23,29 +25,30 @@ def update_sptype(sptypes):
 
     Returns
     -------
-    np.ndarray
-        Updated spectral types.
+    list(str)
+        Output spectral types.
     """
 
     sptype_list = ['O', 'B', 'A', 'F', 'G', 'K', 'M', 'L', 'T', 'Y']
 
+    sptypes_updated = []
+
     for i, spt_item in enumerate(sptypes):
+
         if spt_item == 'None':
-            pass
+            sptypes_updated.append('None')
 
         elif spt_item == 'null':
-            sptypes[i] = 'None'
+            sptypes_updated.append('None')
 
         else:
-            for list_item in sptype_list:
-                try:
-                    sp_index = spt_item.index(list_item)
-                    sptypes[i] = spt_item[sp_index:sp_index+2]
+            if len(spt_item) > 1 and spt_item[0] in sptype_list and spt_item[1].isnumeric():
+                sptypes_updated.append(spt_item[:2])
 
-                except ValueError:
-                    pass
+            else:
+                sptypes_updated.append('None')
 
-    return sptypes
+    return sptypes_updated
 
 
 def update_filter(filter_in):

--- a/species/util/plot_util.py
+++ b/species/util/plot_util.py
@@ -9,17 +9,23 @@ import numpy as np
 from typeguard import typechecked
 
 
-def sptype_substellar(sptype,
-                      shape):
+@typechecked
+def sptype_substellar(sptype: np.ndarray,
+                      shape: Tuple[int]) -> np.ndarray:
     """
+    Function for mapping the spectral types of substellar objects (M, L, T, and Y) to numbers.
+
     Parameters
     ----------
-    sptype :
-    shape :
+    sptype : np.ndarray
+        Array with spectral types.
+    shape : tuple(int)
+        Shape (1D) of the output array
 
     Returns
     -------
-    numpy.ndarray
+    np.ndarray
+        Array with spectral types mapped to numbers.
     """
 
     spt_disc = np.zeros(shape)
@@ -53,17 +59,23 @@ def sptype_substellar(sptype,
     return spt_disc
 
 
-def sptype_stellar(sptype,
-                   shape):
+@typechecked
+def sptype_stellar(sptype: np.ndarray,
+                   shape: Tuple[int]) -> np.ndarray:
     """
+    Function for mapping all spectral types (O through Y) to numbers.
+
     Parameters
     ----------
-    sptype :
-    shape :
+    sptype : np.ndarray
+        Array with spectral types.
+    shape : tuple(int)
+        Shape (1D) of the output array
 
     Returns
     -------
-    numpy.ndarray
+    np.ndarray
+        Array with spectral types mapped to numbers.
     """
 
     spt_disc = np.zeros(shape)

--- a/species/util/read_util.py
+++ b/species/util/read_util.py
@@ -218,7 +218,8 @@ def create_wavelengths(wavel_range: Tuple[Union[float, np.float32], Union[float,
 def smooth_spectrum(wavelength: np.ndarray,
                     flux: np.ndarray,
                     spec_res: float,
-                    size: int = 11) -> np.ndarray:
+                    size: int = 11,
+                    force_smooth: bool = False) -> np.ndarray:
     """
     Function for smoothing a spectrum with a Gaussian kernel to a fixed spectral resolution. The
     kernel size is set to 5 times the FWHM of the Gaussian. The FWHM of the Gaussian is equal
@@ -237,6 +238,8 @@ def smooth_spectrum(wavelength: np.ndarray,
         Spectral resolution.
     size : int
         Kernel size (odd integer).
+    force_smooth : bool
+        Force smoothing for constant spectral resolution
 
     Returns
     -------
@@ -253,7 +256,7 @@ def smooth_spectrum(wavelength: np.ndarray,
     spacing = np.mean(2.*np.diff(wavelength)/(wavelength[1:]+wavelength[:-1]))
     spacing_std = np.std(2.*np.diff(wavelength)/(wavelength[1:]+wavelength[:-1]))
 
-    if spacing_std/spacing < 1e-2:
+    if spacing_std/spacing < 1e-2 or force_smooth:
         # see retrieval_util.convolve
         sigma_lsf = 1./spec_res/(2.*np.sqrt(2.*np.log(2.)))
         flux_smooth = gaussian_filter(flux, sigma=sigma_lsf/spacing, mode='nearest')


### PR DESCRIPTION
- Added the `analysis.empirical.CompareSpectra` class for comparing spectra.
- Currently, `CompareSpectra` has one method, `spectral_type`, which can be used for comparing a spectrum with a library of spectra (which can be added to the database with `add_spectrum`) to find the best matching spectral type.
- The `spectral_type` method has parameters to test different A_V and RV values although the latter is perhaps not needed given the typical spectral resolution.
- Support for the SDSS spectra from Kesseli et al. (2017), which are added as `add_spectrum('kesseli+2017')`.
- Added the `plot_statistic` and `plot_empirical_spectra` functions for plotting the results from `CompareSpectra.spectral_type`.