### PR TITLE
Check MPI rank when storing FitModel

### DIFF
--- a/species/analysis/fit_model.py
+++ b/species/analysis/fit_model.py
@@ -368,8 +368,9 @@ def lnprob(param: np.ndarray,
 
 class FitModel:
     """
-    Class for fitting atmospheric model spectra or blackbody spectra to photometric and/or
-    spectroscopic data.
+    Class for fitting atmospheric model spectra to spectroscopic and/or photometric data, and using
+    Bayesian inference (``UltraNest``, ``MultiNest``, or `emcee`) to estimate posterior
+    distributions and marginalized likelihoods (i.e. "evidence").
     """
 
     @typechecked
@@ -1037,17 +1038,30 @@ class FitModel:
             if f'scaling_{item}' in self.bounds:
                 spec_labels.append(f'scaling_{item}')
 
-        species_db = database.Database()
+        # Get the MPI rank of the process
 
-        species_db.add_samples(sampler='emcee',
-                               samples=ens_sampler.chain,
-                               ln_prob=ens_sampler.lnprobability,
-                               mean_accept=np.mean(ens_sampler.acceptance_fraction),
-                               spectrum=('model', self.model),
-                               tag=tag,
-                               modelpar=self.modelpar,
-                               distance=self.distance[0],
-                               spec_labels=spec_labels)
+        try:
+            from mpi4py import MPI
+            mpi_rank = MPI.COMM_WORLD.Get_rank()
+
+        except ModuleNotFoundError:
+            mpi_rank = 0
+
+        # Add samples to the database
+
+        if mpi_rank == 0:
+            # Writing the samples to the database is only possible when using a single 
+            species_db = database.Database()
+
+            species_db.add_samples(sampler='emcee',
+                                   samples=ens_sampler.chain,
+                                   ln_prob=ens_sampler.lnprobability,
+                                   mean_accept=np.mean(ens_sampler.acceptance_fraction),
+                                   spectrum=('model', self.model),
+                                   tag=tag,
+                                   modelpar=self.modelpar,
+                                   distance=self.distance[0],
+                                   spec_labels=spec_labels)
 
     @typechecked
     def lnlike_func(self,

--- a/species/read/read_model.py
+++ b/species/read/read_model.py
@@ -356,6 +356,17 @@ class ReadModel:
             dust_radius = np.asarray(h5_file['dust/lognorm/mgsio3/crystalline/radius_g'])
             dust_sigma = np.asarray(h5_file['dust/lognorm/mgsio3/crystalline/sigma_g'])
 
+        if wavelength[0] < dust_wavel[0]:
+            raise ValueError(f'The shortest wavelength ({wavelength[0]:.2e} um) for which the '
+                             f'spectrum will be calculated is smaller than the shortest '
+                             f'wavelength ({dust_wavel[0]:.2e} um) of the grid with dust cross '
+                             f'sections.')
+
+        if wavelength[-1] > dust_wavel[-1]:
+            raise ValueError(f'The longest wavelength ({wavelength[-1]:.2e} um) for which the '
+                             f'spectrum  will be calculated is larger than the longest wavelength '
+                             f'({dust_wavel[-1]:.2e} um) of the grid with dust cross sections.')
+
         dust_interp = RegularGridInterpolator((dust_wavel, dust_radius, dust_sigma),
                                               dust_cross,
                                               method='linear',
@@ -437,6 +448,17 @@ class ReadModel:
                                               dust_cross,
                                               method='linear',
                                               bounds_error=True)
+
+        if wavelength[0] < dust_wavel[0]:
+            raise ValueError(f'The shortest wavelength ({wavelength[0]:.2e} um) for which the '
+                             f'spectrum will be calculated is smaller than the shortest '
+                             f'wavelength ({dust_wavel[0]:.2e} um) of the grid with dust cross '
+                             f'sections.')
+
+        if wavelength[-1] > dust_wavel[-1]:
+            raise ValueError(f'The longest wavelength ({wavelength[-1]:.2e} um) for which the '
+                             f'spectrum  will be calculated is larger than the longest wavelength '
+                             f'({dust_wavel[-1]:.2e} um) of the grid with dust cross sections.')
 
         read_filt = read_filter.ReadFilter('Generic/Bessell.V')
         filt_trans = read_filt.get_filter()


### PR DESCRIPTION
- When running `FitModel` with MPI multiprocessing (e.g. with `mpirun`), an error occurred when the samples are stored in the database after `MultiNest` or `UltraNest` has finished. While multiple processes can read from the database at the same time, writing to the database is not possible. As a fix, the rank of the processes is checked and the `add_samples` method is executed only by rank number 0. To make use of the MPI support, it is also required to manually install `mpi4py`.

- Errors are added in `ReadModel` when extinction is applied but the chosen wavelength range goes beyond the wavelength range of the available dust cross sections.