### PR TITLE
Added the smooth_spectrum and resample_spectrum methods to ModelBox

### DIFF
--- a/species/core/box.py
+++ b/species/core/box.py
@@ -1,14 +1,22 @@
 """
-Box module.
+Module with classes for storing data in `Box` objects.
 """
+
+import numpy as np
+import spectres
+
+import species
 
 
 def create_box(boxtype,
                **kwargs):
     """
+    Function for creating a :class:`species.core.box.Box`.
+
     Returns
     -------
     species.core.box
+        Box with the data and parameters.
     """
 
     if boxtype == 'colormag':
@@ -116,7 +124,7 @@ def create_box(boxtype,
 
 class Box:
     """
-    Text
+    Class for generic methods that can be applied on all `Box` object.
     """
 
     def __init__(self):
@@ -129,6 +137,8 @@ class Box:
 
     def open_box(self):
         """
+        Method for inspecting the content of a `Box`.
+
         Returns
         -------
         NoneType
@@ -143,7 +153,7 @@ class Box:
 
 class ColorMagBox(Box):
     """
-    Text
+    Class for storing color-magnitude data in a :class:`species.core.box.Box`.
     """
 
     def __init__(self):
@@ -166,7 +176,7 @@ class ColorMagBox(Box):
 
 class ColorColorBox(Box):
     """
-    Text
+    Class for storing color-color data in a :class:`species.core.box.Box`.
     """
 
     def __init__(self):
@@ -188,7 +198,7 @@ class ColorColorBox(Box):
 
 class IsochroneBox(Box):
     """
-    Text
+    Class for storing isochrone data in a :class:`species.core.box.Box`.
     """
 
     def __init__(self):
@@ -211,7 +221,7 @@ class IsochroneBox(Box):
 
 class ModelBox(Box):
     """
-    Text
+    Class for storing a model spectrum in a :class:`species.core.box.Box`.
     """
 
     def __init__(self):
@@ -229,10 +239,57 @@ class ModelBox(Box):
         self.parameters = None
         self.quantity = None
 
+    def smooth_spectrum(self,
+                        spec_res: float) -> None:
+        """
+        Method for smoothing the spectrum with a Gaussian kernel to the instrument resolution. The
+        method is best applied on an input spectrum with a logarithmic wavelength sampling (i.e.
+        constant spectral resolution). Alternatively, the wavelength sampling may be linear, but
+        the smoothing is slower in that case.
+
+        Parameters
+        ----------
+        spec_res : float
+            Spectral resolution that is used for the smoothing kernel.
+
+        Returns
+        -------
+        NoneType
+            None
+        """
+
+        self.flux = species.util.read_util.smooth_spectrum(
+            self.wavelength, self.flux, spec_res)
+
+    def resample_spectrum(self,
+                          wavel_resample: np.ndarray) -> None:
+        """
+        Method for resampling the spectrum with ``spectres`` to a new wavelength grid.
+
+        Parameters
+        ----------
+        wavel_resample : np.ndarray
+            Wavelength points (um) to which the spectrum will be resampled.
+
+        Returns
+        -------
+        NoneType
+            None
+        """
+
+        self.flux = spectres.spectres(wavel_resample,
+                                      self.wavelength,
+                                      self.flux,
+                                      spec_errs=None,
+                                      fill=np.nan,
+                                      verbose=True)
+
+        self.wavelength = wavel_resample
+
 
 class ObjectBox(Box):
     """
-    Text
+    Class for storing object data in a :class:`species.core.box.Box`.
     """
 
     def __init__(self):
@@ -253,7 +310,7 @@ class ObjectBox(Box):
 
 class PhotometryBox(Box):
     """
-    Text
+    Class for storing photometric data in a :class:`species.core.box.Box`.
     """
 
     def __init__(self):
@@ -275,7 +332,7 @@ class PhotometryBox(Box):
 
 class ResidualsBox(Box):
     """
-    Text
+    Class for storing best-fit residuals in a :class:`species.core.box.Box`.
     """
 
     def __init__(self):
@@ -293,7 +350,7 @@ class ResidualsBox(Box):
 
 class SamplesBox(Box):
     """
-    Text
+    Class for storing posterior samples in a :class:`species.core.box.Box`.
     """
 
     def __init__(self):
@@ -314,7 +371,7 @@ class SamplesBox(Box):
 
 class SpectrumBox(Box):
     """
-    Text
+    Class for storing spectral data in a :class:`species.core.box.Box`.
     """
 
     def __init__(self):
@@ -337,7 +394,7 @@ class SpectrumBox(Box):
 
 class SynphotBox(Box):
     """
-    Text
+    Class for storing synthetic photometry in a :class:`species.core.box.Box`.
     """
 
     def __init__(self):


### PR DESCRIPTION
- The `smooth_spectrum` and `resample_spectrum` methods can be used on a `ModelBox` to smooth and/or resample the model spectrum that is contained in the box.
- Added and improved the docstrings in `core.box`.