### PR TITLE
Empirical low-gravity spectra and development of comparison tools

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@
    :target: https://pypi.python.org/pypi/species
 
 .. image:: https://img.shields.io/travis/tomasstolker/species
-   :target: https://travis-ci.org/tomasstolker/species
+   :target: https://travis-ci.com/tomasstolker/species
 
 .. image:: https://img.shields.io/readthedocs/species
    :target: http://species.readthedocs.io

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -20,8 +20,14 @@ Or, to update to the most recent version:
 
    $ pip install --upgrade species
 
+Please check for any errors and warnings during the installation to make sure that all dependencies are correctly installed.
+
 .. important::
-   Currently it is recommended to install *species* from Github (see below) in order to benefit from the most recent implementations. The available package on PyPI is also stable but it usually trails behind the version on Github.
+   Before installing ``species``, it is required (for ``UltraNest``) to separately install ``cython``:
+
+   .. code-block:: console
+
+       $ pip install cython
 
 Installation from Github
 ------------------------

--- a/docs/species.data.rst
+++ b/docs/species.data.rst
@@ -4,6 +4,14 @@ species.data package
 Submodules
 ----------
 
+species.data.allers2013 module
+------------------------------
+
+.. automodule:: species.data.allers2013
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 species.data.ames\_cond module
 ------------------------------
 
@@ -32,6 +40,14 @@ species.data.blackbody module
 -----------------------------
 
 .. automodule:: species.data.blackbody
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+species.data.bonnefoy2014 module
+--------------------------------
+
+.. automodule:: species.data.bonnefoy2014
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/tutorials/color_magnitude_narrowband.ipynb
+++ b/docs/tutorials/color_magnitude_narrowband.ipynb
@@ -902,7 +902,7 @@
     }
    ],
    "source": [
-    "database.add_spectrum('spex')"
+    "database.add_spectra('spex')"
    ]
   },
   {

--- a/docs/tutorials/spectral_library.ipynb
+++ b/docs/tutorials/spectral_library.ipynb
@@ -119,7 +119,7 @@
     }
    ],
    "source": [
-    "database.add_spectrum(spec_library='irtf', sptypes=['L', 'T'])"
+    "database.add_spectra(spec_library='irtf', sptypes=['L', 'T'])"
    ]
   },
   {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 astropy ~= 4.1.0
 astroquery ~= 0.4.0
 corner ~= 2.1.0
-cython ~= 0.29.0
 emcee ~= 3.0.0
 h5py ~= 2.10.0
 matplotlib ~= 3.3.0

--- a/species/analysis/compare_spectra.py
+++ b/species/analysis/compare_spectra.py
@@ -11,7 +11,10 @@ from typing import List, Optional, Tuple, Union
 import h5py
 import numpy as np
 
+import matplotlib.pyplot as plt
+
 from scipy.interpolate import interp1d
+from scipy.optimize import curve_fit
 from typeguard import typechecked
 
 from species.core import constants
@@ -38,8 +41,8 @@ class CompareSpectra:
             :func:`~species.data.database.Database.add_object` or
             :func:`~species.data.database.Database.add_companion`.
         spec_name : str, list(str)
-            Name of the spectrum  that is stored at the object data of ``object_name``. The
-            argument can be either a string or a list of strings.
+            Name of the spectrum or list with spectrum names that are stored at the object data
+            of ``object_name``. The argument can be either a string or a list of strings.
         spec_library : str, None
             DEPRECATED: Name of the spectral library ('irtf', 'spex', or 'kesseli+2017).
 
@@ -88,7 +91,7 @@ class CompareSpectra:
             will be stored. So when testing a range of values for ``av_ext`` and ``rad_vel``, only
             the parameters that minimize the goodness-of-fit statistic will be stored.
         spec_library : str
-            Name of the spectral library ('irtf', 'spex', or 'kesseli+2017).
+            Name of the spectral library ('irtf', 'spex', 'kesseli+2017', 'bonnefoy+2014').
         wavel_range : tuple(float, float), None
             Wavelength range (um) that is used for the empirical comparison.
         sptypes : list(str), None
@@ -123,21 +126,22 @@ class CompareSpectra:
         except KeyError:
             h5_file.close()
             species_db = database.Database()
-            species_db.add_spectrum(spec_library)
+            species_db.add_spectra(spec_library)
             h5_file = h5py.File(self.database, 'r')
 
-        if len(self.spec_name) > 1:
-            raise ValueError('The \'spectral_type\' method supports only a single spectrum name. '
-                             'Please set the argument of \'spec_name\' to a string.')
+        # Read object spectra and resolution
 
-        # Read object spectrum
-        obj_spec = self.object.get_spectrum()[self.spec_name][0]
+        obj_spec = []
+        obj_res = []
+
+        for item in self.spec_name:
+            obj_spec.append(self.object.get_spectrum()[item][0])
+            obj_res.append(self.object.get_spectrum()[item][3])
 
         # Read inverted covariance matrix
         # obj_inv_cov = self.object.get_spectrum()[self.spec_name][2]
 
-        # Read spectral resolution
-        obj_res = self.object.get_spectrum()[self.spec_name][3]
+        # Create empty lists for results
 
         name_list = []
         spt_list = []
@@ -147,6 +151,8 @@ class CompareSpectra:
         rv_list = []
 
         print_message = ''
+
+        # Start looping over library spectra
 
         for i, item in enumerate(h5_file[f'spectra/{spec_library}']):
             # Read spectrum spectral type from library
@@ -191,50 +197,66 @@ class CompareSpectra:
                 print_message = f'Processing spectra... {item}'
                 print(f'\r{print_message}', end='')
 
+                # Loop over all values of A_V and RV that will be tested
+
                 for av_item in av_ext:
                     for rv_item in rad_vel:
-                        # Dust extinction
-                        ism_ext = dust_util.ism_extinction(av_item, 3.1, spectrum[:, 0])
-                        flux_scaling = 10.**(-0.4*ism_ext)
+                        for j, spec_item in enumerate(obj_spec):
+                            # Dust extinction
+                            ism_ext = dust_util.ism_extinction(av_item, 3.1, spectrum[:, 0])
+                            flux_scaling = 10.**(-0.4*ism_ext)
 
-                        # Shift wavelengths by RV
-                        wavel_shifted = spectrum[:, 0] + spectrum[:, 0]*1e3*rv_item/constants.LIGHT
+                            # Shift wavelengths by RV
+                            wavel_shifted = spectrum[:, 0] + \
+                                spectrum[:, 0]*1e3*rv_item/constants.LIGHT
 
-                        # Smooth spectrum
-                        flux_smooth = read_util.smooth_spectrum(wavel_shifted,
-                                                                spectrum[:, 1]*flux_scaling,
-                                                                spec_res=obj_res,
-                                                                force_smooth=True)
+                            # Smooth spectrum
+                            flux_smooth = read_util.smooth_spectrum(wavel_shifted,
+                                                                    spectrum[:, 1]*flux_scaling,
+                                                                    spec_res=obj_res[j],
+                                                                    force_smooth=True)
 
-                        # Interpolate library spectrum to object wavelengths
-                        interp_spec = interp1d(spectrum[:, 0],
-                                               flux_smooth,
-                                               kind='linear',
-                                               fill_value='extrapolate')
+                            # Interpolate library spectrum to object wavelengths
+                            interp_spec = interp1d(spectrum[:, 0],
+                                                   flux_smooth,
+                                                   kind='linear',
+                                                   fill_value='extrapolate')
 
-                        indices = np.where((obj_spec[:, 0] > np.amin(spectrum[:, 0])) &
-                                           (obj_spec[:, 0] < np.amax(spectrum[:, 0])))[0]
+                            indices = np.where((spec_item[:, 0] > np.amin(spectrum[:, 0])) &
+                                               (spec_item[:, 0] < np.amax(spectrum[:, 0])))[0]
 
-                        flux_resample = interp_spec(obj_spec[indices, 0])
+                            flux_resample = interp_spec(spec_item[indices, 0])
 
-                        c_numer = w_i*obj_spec[indices, 1]*flux_resample/obj_spec[indices, 2]**2
-                        c_denom = w_i*flux_resample**2/obj_spec[indices, 2]**2
+                            c_numer = w_i*spec_item[indices, 1]*flux_resample / \
+                                spec_item[indices, 2]**2
 
-                        c_k = np.sum(c_numer) / np.sum(c_denom)
+                            c_denom = w_i*flux_resample**2/spec_item[indices, 2]**2
 
-                        chi_sq = (obj_spec[indices, 1] - c_k*flux_resample) / obj_spec[indices, 2]
-                        g_k = np.sum(w_i * chi_sq**2)
+                            if j == 0:
+                                g_k = 0.
+                                c_k_spec = []
 
-                        # obj_inv_cov_crop = obj_inv_cov[indices, :]
-                        # obj_inv_cov_crop = obj_inv_cov_crop[:, indices]
-                        #
-                        # g_k = np.dot(obj_spec[indices, 1]-c_k*flux_resample,
-                        #     np.dot(obj_inv_cov_crop, obj_spec[indices, 1]-c_k*flux_resample))
+                            c_k = np.sum(c_numer) / np.sum(c_denom)
+                            c_k_spec.append(c_k)
+
+                            chi_sq = (spec_item[indices, 1] - c_k*flux_resample) / \
+                                spec_item[indices, 2]
+
+                            g_k += np.sum(w_i * chi_sq**2)
+
+                            # obj_inv_cov_crop = obj_inv_cov[indices, :]
+                            # obj_inv_cov_crop = obj_inv_cov_crop[:, indices]
+
+                            # g_k = np.dot(spec_item[indices, 1]-c_k*flux_resample,
+                            #     np.dot(obj_inv_cov_crop,
+                            #            spec_item[indices, 1]-c_k*flux_resample))
+
+                        # Append to the lists of results
 
                         name_list.append(item)
                         spt_list.append(item_sptype)
                         gk_list.append(g_k)
-                        ck_list.append(c_k)
+                        ck_list.append(c_k_spec)
                         av_list.append(av_item)
                         rv_list.append(rv_item)
 
@@ -282,12 +304,14 @@ class CompareSpectra:
         if len(gk_select) < 10:
             for i in range(len(gk_select)):
                 print(f'   {i+1:2d}. G = {gk_select[i]:.2e} -> {name_select[i]}, {spt_select[i]}, '
-                      f'A_V = {av_select[i]:.2f}, RV = {rv_select[i]:.0f} km/s')
+                      f'A_V = {av_select[i]:.2f}, RV = {rv_select[i]:.0f} km/s,\n'
+                      f'                      scalings = {ck_select[i]}')
 
         else:
             for i in range(10):
                 print(f'   {i+1:2d}. G = {gk_select[i]:.2e} -> {name_select[i]}, {spt_select[i]}, '
-                      f'A_V = {av_select[i]:.2f}, RV = {rv_select[i]:.0f} km/s')
+                      f'A_V = {av_select[i]:.2f}, RV = {rv_select[i]:.0f} km/s,\n'
+                      f'                      scalings = {ck_select[i]}')
 
         species_db = database.Database()
 
@@ -306,7 +330,9 @@ class CompareSpectra:
     def compare_model(self,
                       tag: str,
                       model: str,
-                      av_points: Optional[Union[List[float], np.array]] = None) -> None:
+                      av_points: Optional[Union[List[float], np.array]] = None,
+                      fix_logg: Optional[float] = None,
+                      fix_spec: Optional[List[str]] = None) -> None:
         """
         Method for finding the best fitting spectrum from a grid of atmospheric model spectra by
         evaluating the goodness-of-fit statistic from Cushing et al. (2008). Currently, this method
@@ -325,6 +351,12 @@ class CompareSpectra:
         av_points : list(float), np.array, None
             List of :math:`A_V` extinction values for which the goodness-of-fit statistic will be
             tested. The extinction is calculated with the relation from Cardelli et al. (1989).
+        fix_logg : float, None
+            Fix the value of :math:`\log(g)`, for example if estimated from gravity-sensitive
+            spectral features. Typically, :math:`\log(g)` can not be accurately determined when
+            comparing the spectra over a broad wavelength range.
+        fix_spec : list(str), None
+            TODO
 
         Returns
         -------
@@ -332,7 +364,17 @@ class CompareSpectra:
             None
         """
 
-        w_i = 1.
+        w_i = {}
+
+        for spec_item in self.spec_name:
+            obj_wavel = self.object.get_spectrum()[spec_item][0][:, 0]
+
+            diff = (np.diff(obj_wavel)[1:] + np.diff(obj_wavel)[:-1]) / 2.
+            diff = np.insert(diff, 0, diff[0])
+            diff = np.append(diff, diff[-1])
+
+            # w_i[spec_item] = diff
+            w_i[spec_item] = np.ones(obj_wavel.shape[0])
 
         if av_points is None:
             av_points = np.array([0.])
@@ -346,8 +388,18 @@ class CompareSpectra:
         grid_points = readmodel.get_points()
 
         coord_points = []
-        for item in grid_points.values():
-            coord_points.append(item)
+        for key, value in grid_points.items():
+            if key == 'logg' and fix_logg is not None:
+                if fix_logg in value:
+                    coord_points.append(np.array([fix_logg]))
+
+                else:
+                    raise ValueError(f'The argument of \'fix_logg\' ({fix_logg}) is not found '
+                                     f'in the parameter grid of the model spectra. The following '
+                                     f'values of log(g) are available: {value}')
+
+            else:
+                coord_points.append(value)
 
         if av_points is not None:
             model_param.append('ism_ext')
@@ -369,6 +421,8 @@ class CompareSpectra:
 
             for i, item_i in enumerate(coord_points[0]):
                 for j, item_j in enumerate(coord_points[1]):
+                    model_spec = {}
+
                     for k, spec_item in enumerate(self.spec_name):
                         print(f'Processing model spectrum {count}/{n_iter}...', end='')
 
@@ -385,13 +439,18 @@ class CompareSpectra:
                                                        spec_res=obj_res,
                                                        wavel_resample=obj_spec[:, 0])
 
-                        c_numer = w_i * obj_spec[:, 1] * model_box.flux / obj_spec[:, 2]**2
-                        c_denom = w_i * model_box.flux**2 / obj_spec[:, 2]**2
+                        model_spec[spec_item] = model_box.flux
+
+                    for k, spec_item in enumerate(self.spec_name):
+                        obj_spec = self.object.get_spectrum()[spec_item][0]
+
+                        c_numer = w_i[spec_item] * obj_spec[:, 1] * model_spec[spec_item] / obj_spec[:, 2]**2
+                        c_denom = w_i[spec_item] * model_spec[spec_item]**2 / obj_spec[:, 2]**2
 
                         flux_scaling[i, j, k] = np.sum(c_numer) / np.sum(c_denom)
 
-                        residual = obj_spec[:, 1] - flux_scaling[i, j, k]*model_box.flux
-                        fit_stat[i, j, k] = np.sum(w_i * (residual/obj_spec[:, 2])**2)
+                        residual = obj_spec[:, 1] - flux_scaling[i, j, k]*model_spec[spec_item]
+                        fit_stat[i, j, k] = np.sum(w_i[spec_item] * (residual/obj_spec[:, 2])**2)
 
                     count += 1
 
@@ -401,6 +460,8 @@ class CompareSpectra:
             for i, item_i in enumerate(coord_points[0]):
                 for j, item_j in enumerate(coord_points[1]):
                     for k, item_k in enumerate(coord_points[2]):
+                        model_spec = {}
+
                         for m, spec_item in enumerate(self.spec_name):
                             print(f'\rProcessing model spectrum {count}/{n_iter}...', end='')
 
@@ -418,13 +479,65 @@ class CompareSpectra:
                                                            spec_res=obj_res,
                                                            wavel_resample=obj_spec[:, 0])
 
-                            c_numer = w_i * obj_spec[:, 1] * model_box.flux / obj_spec[:, 2]**2
-                            c_denom = w_i * model_box.flux**2 / obj_spec[:, 2]**2
+                            model_spec[spec_item] = model_box.flux
 
-                            flux_scaling[i, j, k, m] = np.sum(c_numer) / np.sum(c_denom)
+                        if fix_spec is not None:
+                            for spec_item in fix_spec:
+                                if spec_item == fix_spec[0]:
+                                    obj_add = self.object.get_spectrum()[spec_item][0]
 
-                            residual = obj_spec[:, 1] - flux_scaling[i, j, k, m]*model_box.flux
-                            fit_stat[i, j, k, m] = np.sum(w_i * (residual/obj_spec[:, 2])**2)
+                                    # TODO
+                                    if spec_item == 'MUSE':
+                                        obj_add[:, 2] *= 3.
+
+                                    model_add = model_spec[spec_item]
+                                    w_i_add = w_i[spec_item]
+
+                                else:
+                                    spec_tmp = self.object.get_spectrum()[spec_item][0]
+                                    obj_add = np.vstack((obj_add, spec_tmp))
+                                    model_add = np.append(model_add, model_spec[spec_item])
+                                    w_i_add = np.append(w_i_add, w_i[spec_item])
+
+                            c_numer = w_i_add * obj_add[:, 1] * model_add / obj_add[:, 2]**2
+                            c_denom = w_i_add * model_add**2 / obj_add[:, 2]**2
+
+                            scaling_fix = np.sum(c_numer) / np.sum(c_denom)
+
+                            residual = obj_add[:, 1] - scaling_fix*model_add
+                            stat_fix = np.sum(w_i_add * (residual/obj_add[:, 2])**2)
+
+                            # def func(x, scaling):
+                            #     return scaling*model_add
+                            #
+                            # popt, pcov = curve_fit(func, xdata=obj_add[:, 0], ydata=obj_add[:, 1])
+                            # scaling_fix = popt[0]
+
+                            # if item_i == 2600. and item_k == 1.:
+                            #     plt.plot(obj_add[:, 0], obj_add[:, 1])
+                            #     plt.plot(obj_add[:, 0], scaling_fix*model_add)
+                            #     plt.show()
+                            #     exit()
+
+                        for m, spec_item in enumerate(self.spec_name):
+                            if fix_spec is not None and spec_item == fix_spec[0]:
+                                flux_scaling[i, j, k, m] = scaling_fix
+                                fit_stat[i, j, j, m] = stat_fix
+
+                            elif fix_spec is not None and spec_item in fix_spec:
+                                flux_scaling[i, j, k, m] = scaling_fix
+                                fit_stat[i, j, j, m] = 0.
+
+                            else:
+                                obj_spec = self.object.get_spectrum()[spec_item][0]
+
+                                c_numer = w_i[spec_item] * obj_spec[:, 1] * model_spec[spec_item] / obj_spec[:, 2]**2
+                                c_denom = w_i[spec_item] * model_spec[spec_item]**2 / obj_spec[:, 2]**2
+
+                                flux_scaling[i, j, k, m] = np.sum(c_numer) / np.sum(c_denom)
+
+                                residual = obj_spec[:, 1] - flux_scaling[i, j, k, m]*model_spec[spec_item]
+                                fit_stat[i, j, k, m] = np.sum(w_i[spec_item] * (residual/obj_spec[:, 2])**2)
 
                         count += 1
 

--- a/species/analysis/compare_spectra.py
+++ b/species/analysis/compare_spectra.py
@@ -302,8 +302,8 @@ class CompareSpectra:
         print('Best-fitting spectra:')
 
         if len(gk_select) < 10:
-            for i in range(len(gk_select)):
-                print(f'   {i+1:2d}. G = {gk_select[i]:.2e} -> {name_select[i]}, {spt_select[i]}, '
+            for i, gk_item in enumerate(gk_select):
+                print(f'   {i+1:2d}. G = {gk_item:.2e} -> {name_select[i]}, {spt_select[i]}, '
                       f'A_V = {av_select[i]:.2f}, RV = {rv_select[i]:.0f} km/s,\n'
                       f'                      scalings = {ck_select[i]}')
 

--- a/species/analysis/compare_spectra.py
+++ b/species/analysis/compare_spectra.py
@@ -356,7 +356,7 @@ class CompareSpectra:
             spectral features. Typically, :math:`\log(g)` can not be accurately determined when
             comparing the spectra over a broad wavelength range.
         fix_spec : list(str), None
-            TODO
+            List with names of spectra for which the relative scaling will be fixed.
 
         Returns
         -------
@@ -486,9 +486,8 @@ class CompareSpectra:
                                 if spec_item == fix_spec[0]:
                                     obj_add = self.object.get_spectrum()[spec_item][0]
 
-                                    # TODO
-                                    if spec_item == 'MUSE':
-                                        obj_add[:, 2] *= 3.
+                                    # if spec_item == 'MUSE':
+                                    #     obj_add[:, 2] *= 3.
 
                                     model_add = model_spec[spec_item]
                                     w_i_add = w_i[spec_item]

--- a/species/analysis/photometry.py
+++ b/species/analysis/photometry.py
@@ -81,7 +81,7 @@ class SyntheticPhotometry:
         except KeyError:
             h5_file.close()
             species_db = database.Database()
-            species_db.add_spectrum('vega')
+            species_db.add_spectra('vega')
             h5_file = h5py.File(self.database, 'r')
 
         readcalib = read_calibration.ReadCalibration('vega', None)

--- a/species/data/allers2013.py
+++ b/species/data/allers2013.py
@@ -1,0 +1,110 @@
+"""
+Module for adding young, M- and L-type dwarf spectra from
+`Allers & Liu (2013) <https://ui.adsabs.harvard.edu/abs/2013ApJ...772...79A/abstract>`_ to the
+database. All  spectra are also available in the
+`SpeX Prism Library Analysis Toolkit <https://github.com/aburgasser/splat>`_.
+"""
+
+import os
+import shutil
+import tarfile
+import urllib.request
+
+import h5py
+import numpy as np
+
+from astropy.io import fits
+from typeguard import typechecked
+
+
+@typechecked
+def add_allers2013(input_path: str,
+                   database: h5py._hl.files.File) -> None:
+    """
+    Function for adding the spectra of young, M- and L-type dwarfs from
+    `Allers & Liu (2013) <https://ui.adsabs.harvard.edu/abs/2013ApJ...772...79A/abstract>`_  to
+    the database.
+
+    Parameters
+    ----------
+    input_path : str
+        Path of the data folder.
+    database : h5py._hl.files.File
+        The HDF5 database.
+
+    Returns
+    -------
+    NoneType
+        None
+    """
+
+    print_text = 'spectra of young M/L type objects from Allers & Liu 2013'
+
+    data_url = 'https://home.strw.leidenuniv.nl/~stolker/species/allers_liu_2013.tgz'
+    data_file = os.path.join(input_path, 'allers_liu_2013.tgz')
+    data_folder = os.path.join(input_path, 'allers+2014/')
+
+    if not os.path.isfile(data_file):
+        print(f'Downloading {print_text} (173 kB)...', end='', flush=True)
+        urllib.request.urlretrieve(data_url, data_file)
+        print(' [DONE]')
+
+    if os.path.exists(data_folder):
+        shutil.rmtree(data_folder)
+
+    print(f'Unpacking {print_text} (173 kB)...', end='', flush=True)
+    tar = tarfile.open(data_file)
+    tar.extractall(data_folder)
+    tar.close()
+    print(' [DONE]')
+
+    sources = np.genfromtxt(os.path.join(data_folder, 'sources.csv'),
+                            delimiter=',', dtype=None, encoding='ASCII')
+
+    source_names = sources[:, 0]
+    source_sptype = sources[:, 7]
+
+    database.create_group('spectra/allers+2013')
+
+    print_message = ''
+
+    for _, _, files in os.walk(data_folder):
+        for _, filename in enumerate(files):
+            if filename.endswith('.fits'):
+                sp_data, header = fits.getdata(os.path.join(data_folder, filename), header=True)
+
+            else:
+                continue
+
+            sp_data = np.transpose(sp_data)
+
+            # (erg s-1 cm-2 A-1) -> (W m-2 um-1)
+            sp_data[:, 1:] *= 10.
+
+            name = header['OBJECT']
+
+            index = np.argwhere(source_names == name)
+
+            if len(index) == 0:
+                sptype = None
+            else:
+                sptype = source_sptype[index][0][0][:2]
+
+            empty_message = len(print_message) * ' '
+            print(f'\r{empty_message}', end='')
+
+            print_message = f'Adding spectra... {name}'
+            print(f'\r{print_message}', end='')
+
+            dset = database.create_dataset(f'spectra/allers+2013/{name}', data=sp_data)
+
+            dset.attrs['name'] = str(name).encode()
+            dset.attrs['sptype'] = str(sptype).encode()
+
+    empty_message = len(print_message) * ' '
+    print(f'\r{empty_message}', end='')
+
+    print_message = 'Adding spectra... [DONE]'
+    print(f'\r{print_message}')
+
+    database.close()

--- a/species/data/bonnefoy2014.py
+++ b/species/data/bonnefoy2014.py
@@ -1,0 +1,146 @@
+"""
+Module for adding young, M- and L-type dwarf spectra from
+`Bonnefoy et al. (2014) <https://ui.adsabs.harvard.edu/abs/2014A%26A...562A.127B/abstract>`_ to
+the database.
+"""
+
+import gzip
+import os
+import shutil
+import tarfile
+import urllib.request
+
+import h5py
+import numpy as np
+
+from astropy.io import fits
+from typeguard import typechecked
+
+
+@typechecked
+def add_bonnefoy2014(input_path: str,
+                     database: h5py._hl.files.File) -> None:
+    """
+    Function for adding the SINFONI spectra of young, M- and L-type dwarfs from
+    `Bonnefoy et al. (2014) <https://ui.adsabs.harvard.edu/abs/2014A%26A...562A.127B/abstract>`_ to
+    the database.
+
+    Parameters
+    ----------
+    input_path : str
+        Path of the data folder.
+    database : h5py._hl.files.File
+        The HDF5 database.
+
+    Returns
+    -------
+    NoneType
+        None
+    """
+
+    print_text = 'spectra of young M/L type objects from Bonnefoy et al. 2014'
+
+    data_url = 'http://cdsarc.u-strasbg.fr/viz-bin/nph-Cat/tar.gz?J/A+A/562/A127/'
+    data_file = os.path.join(input_path, 'J_A+A_562_A127.tar.gz')
+    data_folder = os.path.join(input_path, 'bonnefoy+2014/')
+
+    if not os.path.isfile(data_file):
+        print(f'Downloading {print_text} (2.3 MB)...', end='', flush=True)
+        urllib.request.urlretrieve(data_url, data_file)
+        print(' [DONE]')
+
+    if os.path.exists(data_folder):
+        shutil.rmtree(data_folder)
+
+    print(f'Unpacking {print_text} (2.3 MB)...', end='', flush=True)
+    tar = tarfile.open(data_file)
+    tar.extractall(data_folder)
+    tar.close()
+    print(' [DONE]')
+
+    spec_dict = {}
+
+    with gzip.open(os.path.join(data_folder, 'stars.dat.gz'), 'r') as gzip_file:
+        for line in gzip_file:
+            name = line[:13].decode().strip()
+            files = line[80:].decode().strip().split()
+            sptype = line[49:56].decode().strip()
+
+            if name == 'NAME 2M1207A':
+                name = '2M1207A'
+
+            if len(sptype) == 0:
+                sptype = None
+            elif '.' in sptype:
+                sptype = sptype[:4]
+            else:
+                sptype = sptype[:2]
+
+            if name == 'Cha1109':
+                sptype = 'M9'
+            elif name == 'DH Tau B':
+                sptype = 'M9'
+            elif name == 'TWA 22A':
+                sptype = 'M6'
+            elif name == 'TWA 22B':
+                sptype = 'M6'
+            elif name == 'CT Cha b':
+                sptype = 'M9'
+
+            spec_dict[name] = {'name': name, 'sptype': sptype, 'files': files}
+
+    database.create_group('spectra/bonnefoy+2014')
+
+    fits_folder = os.path.join(data_folder, 'sp')
+
+    print_message = ''
+
+    for _, _, files in os.walk(fits_folder):
+        for _, filename in enumerate(files):
+            fname_split = filename.split('_')
+
+            data = fits.getdata(os.path.join(fits_folder, filename))
+
+            for name, value in spec_dict.items():
+                if filename in value['files']:
+                    if name == 'TWA 22AB':
+                        # Binary spectrum
+                        continue
+
+                    if 'JHK.fits' in fname_split:
+                        spec_dict[name]['JHK'] = data
+
+                    elif 'J' in fname_split:
+                        spec_dict[name]['J'] = data
+
+                    elif 'H+K' in fname_split or 'HK' in fname_split:
+                        spec_dict[name]['HK'] = data
+
+    for name, value in spec_dict.items():
+        empty_message = len(print_message) * ' '
+        print(f'\r{empty_message}', end='')
+
+        print_message = f'Adding spectra... {name}'
+        print(f'\r{print_message}', end='')
+
+        if 'JHK' in value:
+            sp_data = value['JHK']
+
+        elif 'J' in value and 'HK' in value:
+            sp_data = np.vstack((value['J'], value['HK']))
+
+        else:
+            continue
+
+        dset = database.create_dataset(f'spectra/bonnefoy+2014/{name}', data=sp_data)
+
+        dset.attrs['name'] = str(name).encode()
+        dset.attrs['sptype'] = str(value['sptype']).encode()
+
+    empty_message = len(print_message) * ' '
+    print(f'\r{empty_message}', end='')
+
+    print_message = 'Adding spectra... [DONE]'
+    print(f'\r{print_message}')
+
+    database.close()

--- a/species/data/companions.py
+++ b/species/data/companions.py
@@ -229,8 +229,8 @@ def get_data() -> Dict[str, Dict[str, Union[bool, Tuple[float, float],
                                      'Magellan/VisAO.ip': (18.89, 0.24),  # Wu et al. 2017
                                      'Magellan/VisAO.zp': (16.40, 0.10),  # Wu et al. 2017
                                      'Magellan/VisAO.Ys': (15.88, 0.10),  # Wu et al. 2017
-                                     # 'MKO/NSFCam.H': (14.02, 0.13),  # Stolker et al. in prep.
-                                     'Paranal/NACO.NB405': (12.29, 0.07),  # Stolker et al. in prep.
+                                     'MKO/NSFCam.H': (14.01, 0.13),  # Stolker et al. in prep.
+                                     'Paranal/NACO.NB405': (12.29, 0.06),  # Stolker et al. in prep.
                                      'Paranal/NACO.Mp': (11.97, 0.08),  # Stolker et al. in prep.
                                      'Paranal/NACO.Ks': [(13.474, 0.031),  # Ginski et al. 2014
                                                          (13.386, 0.032),  # Ginski et al. 2014
@@ -245,6 +245,7 @@ def get_data() -> Dict[str, Dict[str, Union[bool, Tuple[float, float],
                          'radius_companion': (3.6, 0.1),  # Stolker et al. in prep.
                          'accretion': True,  # Seifahrt et al. 2007
                          'line_flux': {'h-alpha': (3.31e-18, 0.04e-18),  # Stolker et al. in prep.
+                                       'h-beta': (2.7e-19, 2.7e-19),  # Stolker et al. in prep.
                                        'pa-beta': (1.32e-18, 0.01e-18)}},  # Stolker et al. in prep.
 
             'PZ Tel B': {'distance': (47.13, 0.13),
@@ -301,9 +302,9 @@ def get_data() -> Dict[str, Dict[str, Union[bool, Tuple[float, float],
                           'accretion': False},
 
             'ROXs 42 Bb': {'distance': (144.16, 1.53),
-                           'app_mag': {'Keck/NIRC2.J': (16.91, 0.11),  # Daemgen et al. 2017
-                                       'Keck/NIRC2.H': (15.88, 0.05),  # Daemgen et al. 2017
-                                       'Keck/NIRC2.Ks': (15.01, 0.06),  # Daemgen et al. 2017
+                           'app_mag': {'Keck/NIRC2.J': (16.91, 0.11),  # Currie et al. 2014b
+                                       'Keck/NIRC2.H': (15.88, 0.05),  # Currie et al. 2014a
+                                       'Keck/NIRC2.Ks': (15.01, 0.06),  # Currie et al. 2014b
                                        'Keck/NIRC2.Lp': (13.97, 0.06),  # Daemgen et al. 2017
                                        'Keck/NIRC2.NB_4.05': (13.90, 0.08),  # Daemgen et al. 2017
                                        'Keck/NIRC2.Ms': (14.01, 0.23)},  # Daemgen et al. 2017
@@ -443,9 +444,13 @@ def get_data() -> Dict[str, Dict[str, Union[bool, Tuple[float, float],
                            'accretion': False},
 
             'HD 142527 B': {'distance': (159.26, 0.72),
-                            'app_mag': {'Paranal/NACO.H': (10.5, 0.2),  # Biller et al. 2012
-                                        'Paranal/NACO.Ks': (10.0, 0.3),  # Biller et al. 2012
-                                        'Paranal/NACO.Lp': (9.1, 0.1),  # Biller et al. 2012
+                            'app_mag': {'Paranal/NACO.J': (10.86, 0.05),  # Lacour et al. 2016
+                                        'Paranal/NACO.H': [(10.5, 0.2),  # Biller et al. 2012
+                                                           (10.3, 0.5)],  # Lacour et al. 2012
+                                        'Paranal/NACO.Ks': [(10.0, 0.3),  # Biller et al. 2012
+                                                            (9.8, 0.1)],  # Lacour et al. 2016
+                                        'Paranal/NACO.Lp': [(9.1, 0.1),  # Biller et al. 2012
+                                                            (9.1, 0.1)],  # Lacour et al. 2016
                                         'Paranal/NACO.Mp': (9.2, 0.2)},  # Lacour et al. 2016
                             'semi_major': (38., 20.),  # Claudi et al. 2019
                             'mass_star': (2.0, 0.3),  # Mendigutía et al. 2014

--- a/species/data/database.py
+++ b/species/data/database.py
@@ -22,7 +22,7 @@ from species.core import box, constants
 from species.data import ames_cond, ames_dusty, atmo, blackbody, btcond, btcond_feh, btnextgen, \
                          btsettl, btsettl_cifist, companions, drift_phoenix, dust, exo_rem, \
                          filters, irtf, isochrones, leggett, petitcode, spex, vega, vlm_plx, \
-                         kesseli2017, morley2012
+                         kesseli2017, morley2012, bonnefoy2014, allers2013
 from species.read import read_calibration, read_filter, read_model, read_object, read_planck
 from species.util import data_util, dust_util, read_util
 
@@ -153,7 +153,7 @@ class Database:
         """
         Function for adding the magnitudes and spectra of directly imaged planets and brown dwarfs
         from :class:`~species.data.companions.get_data` and
-        :class:`~species.data.companions.get_comp_spec`to the database.
+        :class:`~species.data.companions.get_comp_spec` to the database.
 
         Parameters
         ----------
@@ -618,7 +618,7 @@ class Database:
 
         if app_mag is not None:
             if 'spectra/calibration/vega' not in h5_file:
-                self.add_spectrum('vega')
+                self.add_spectra('vega')
 
             for item in app_mag:
                 if f'filters/{item}' not in h5_file:
@@ -626,7 +626,7 @@ class Database:
 
         if flux_density is not None:
             if 'spectra/calibration/vega' not in h5_file:
-                self.add_spectrum('vega')
+                self.add_spectra('vega')
 
             for item in flux_density:
                 if f'filters/{item}' not in h5_file:
@@ -800,9 +800,8 @@ class Database:
             for flux_item in flux_density:
                 if isinstance(deredden, float) or flux_item in deredden:
                     warnings.warn(f'The deredden parameter is not supported by flux_density. '
-                                  f'Please use app_mag instead or contact Tomas Stolker and ask '
-                                  f'if the flux_density support can be added. Ignoring the '
-                                  f'dereddening of {flux_item}.')
+                                  f'Please use app_mag instead and/or open an issue on Github. '
+                                  f'Ignoring the dereddening of {flux_item}.')
 
                 if f'objects/{object_name}/{flux_item}' in h5_file:
                     del h5_file[f'objects/{object_name}/{flux_item}']
@@ -822,7 +821,7 @@ class Database:
                     dset = h5_file.create_dataset(f'objects/{object_name}/{flux_item}',
                                                   data=data)
 
-                    dset.attrs['n_phot'] = n_phot
+                    dset.attrs['n_phot'] = 1
 
         if spectrum is not None:
             read_spec = {}
@@ -1139,10 +1138,62 @@ class Database:
                      spec_library: str,
                      sptypes: Optional[List[str]] = None) -> None:
         """
+        DEPRECATION: This method is deprecated and will be removed in a future release. Please use
+        the :meth:`~species.data.database.Database.add_spectra` method instead.
+
         Parameters
         ----------
         spec_library : str
-            Spectral library ('irtf', 'spex', 'kesseli+2017').
+            Spectral library ('irtf', 'spex', 'kesseli+2017', 'bonnefoy+2014', 'allers+2013').
+        sptypes : list(str)
+            Spectral types ('F', 'G', 'K', 'M', 'L', 'T'). Currently only implemented for 'irtf'.
+
+        Returns
+        -------
+        NoneType
+            None
+        """
+
+        warnings.warn('This method is deprecated and will be removed in a future release. Please '
+                      'use the add_spectra method instead.')
+
+        h5_file = h5py.File(self.database, 'a')
+
+        if 'spectra' not in h5_file:
+            h5_file.create_group('spectra')
+
+        if 'spectra/'+spec_library in h5_file:
+            del h5_file['spectra/'+spec_library]
+
+        if spec_library[0:5] == 'vega':
+            vega.add_vega(self.input_path, h5_file)
+
+        elif spec_library[0:5] == 'irtf':
+            irtf.add_irtf(self.input_path, h5_file, sptypes)
+
+        elif spec_library[0:5] == 'spex':
+            spex.add_spex(self.input_path, h5_file)
+
+        elif spec_library[0:12] == 'kesseli+2017':
+            kesseli2017.add_kesseli2017(self.input_path, h5_file)
+
+        elif spec_library[0:13] == 'bonnefoy+2014':
+            bonnefoy2014.add_bonnefoy2014(self.input_path, h5_file)
+
+        elif spec_library[0:11] == 'allers+2013':
+            allers2013.add_allers2013(self.input_path, h5_file)
+
+        h5_file.close()
+
+    @typechecked
+    def add_spectra(self,
+                    spec_library: str,
+                    sptypes: Optional[List[str]] = None) -> None:
+        """
+        Parameters
+        ----------
+        spec_library : str
+            Spectral library ('irtf', 'spex', 'kesseli+2017', 'bonnefoy+2014', 'allers+2013').
         sptypes : list(str)
             Spectral types ('F', 'G', 'K', 'M', 'L', 'T'). Currently only implemented for 'irtf'.
 
@@ -1171,6 +1222,12 @@ class Database:
 
         elif spec_library[0:12] == 'kesseli+2017':
             kesseli2017.add_kesseli2017(self.input_path, h5_file)
+
+        elif spec_library[0:13] == 'bonnefoy+2014':
+            bonnefoy2014.add_bonnefoy2014(self.input_path, h5_file)
+
+        elif spec_library[0:11] == 'allers+2013':
+            allers2013.add_allers2013(self.input_path, h5_file)
 
         h5_file.close()
 
@@ -1460,6 +1517,7 @@ class Database:
                     if spec_name == spec_fix:
                         continue
 
+                    # Factor for scaling the observed spectrum to the model spectrum
                     model_param[f'scaling_{spec_name}'] = (
                         dset.attrs[f'radius_{spec_fix}'] / dset.attrs[f'radius_{spec_name}'])**2
 
@@ -1934,11 +1992,11 @@ class Database:
                       names: List[str],
                       sptypes: List[str],
                       goodness_of_fit: List[float],
-                      flux_scaling: List[float],
+                      flux_scaling: List[np.ndarray],
                       av_ext: List[float],
                       rad_vel: List[float],
                       object_name: str,
-                      spec_name: str,
+                      spec_name: List[str],
                       spec_library: str) -> None:
         """
         Parameters
@@ -1951,8 +2009,10 @@ class Database:
             Array with the spectral types of ``names``.
         goodness_of_fit : list(float)
             Array with the goodness-of-fit values.
-        flux_scaling : list(float)
-            Array with the best-fit scaling values to match the library spectra with the data.
+        flux_scaling : list(np.ndarray)
+            List with arrays with the best-fit scaling values to match the library spectra with
+            the data. The size of each array is equal to the number of spectra that are provided
+            as argument of ``spec_name``.
         av_ext : list(float)
             Array with the visual extinction :math:`A_V`.
         rad_vel : list(float)
@@ -1961,8 +2021,8 @@ class Database:
             Object name as stored in the database with
             :func:`~species.data.database.Database.add_object` or
             :func:`~species.data.database.Database.add_companion`.
-        spec_name : str
-            Name of the spectrum that is stored at the object data of ``object_name``.
+        spec_name : list(str)
+            List with spectrum names that are stored at the object data of ``object_name``.
         spec_library : str
             Name of the spectral library that was used for the empirical comparison.
 
@@ -1991,8 +2051,11 @@ class Database:
             dset[...] = names
 
             dset.attrs['object_name'] = str(object_name)
-            dset.attrs['spec_name'] = str(spec_name)
             dset.attrs['spec_library'] = str(spec_library)
+            dset.attrs['n_spec_name'] = len(spec_name)
+
+            for i, item in enumerate(spec_name):
+                dset.attrs[f'spec_name{i}'] = item
 
             dset = h5_file.create_dataset(f'results/empirical/{tag}/sptypes',
                                           (np.size(sptypes), ), dtype=dtype)

--- a/species/data/irtf.py
+++ b/species/data/irtf.py
@@ -135,7 +135,7 @@ def add_irtf(input_path: str,
                         empty_message = len(print_message) * ' '
                         print(f'\r{empty_message}', end='')
 
-                        print_message = f'Adding IRTF Spectral Library... {name}'
+                        print_message = f'Adding spectra... {name}'
                         print(f'\r{print_message}', end='')
 
                         simbad_id = query_util.get_simbad(name)
@@ -169,7 +169,7 @@ def add_irtf(input_path: str,
     empty_message = len(print_message) * ' '
     print(f'\r{empty_message}', end='')
 
-    print_message = 'Adding IRTF Spectral Library... [DONE]'
+    print_message = 'Adding spectra... [DONE]'
     print(f'\r{print_message}')
 
     database.close()

--- a/species/data/kesseli2017.py
+++ b/species/data/kesseli2017.py
@@ -37,9 +37,6 @@ def add_kesseli2017(input_path: str,
     data_file = os.path.join(input_path, 'J_ApJS_230_16.tar.gz')
     data_folder = os.path.join(input_path, 'kesseli+2017/')
 
-    if not os.path.exists(data_folder):
-        os.makedirs(data_folder)
-
     if not os.path.isfile(data_file):
         print('Downloading SDSS spectra from Kesseli et al. 2017 (145 MB)...', end='', flush=True)
         urllib.request.urlretrieve(data_url, data_file)
@@ -62,38 +59,37 @@ def add_kesseli2017(input_path: str,
 
     for _, _, files in os.walk(fits_folder):
         for _, filename in enumerate(files):
-            if filename[-4:] != '.fits':
-                with fits.open(os.path.join(fits_folder, filename)) as hdu_list:
-                    data = hdu_list[1].data
+            with fits.open(os.path.join(fits_folder, filename)) as hdu_list:
+                data = hdu_list[1].data
 
-                    wavelength = 1e-4*10.**data['LogLam']  # (um)
-                    flux = data['Flux']  # Normalized units
-                    error = data['PropErr']  # Normalized units
+                wavelength = 1e-4*10.**data['LogLam']  # (um)
+                flux = data['Flux']  # Normalized units
+                error = data['PropErr']  # Normalized units
 
-                    name = filename[:-5].replace('_', ' ')
+                name = filename[:-5].replace('_', ' ')
 
-                    file_split = filename.split('_')
-                    file_split = file_split[0].split('.')
+                file_split = filename.split('_')
+                file_split = file_split[0].split('.')
 
-                    sptype = file_split[0]
+                sptype = file_split[0]
 
-                    spdata = np.column_stack([wavelength, flux, error])
+                spdata = np.column_stack([wavelength, flux, error])
 
-                    empty_message = len(print_message) * ' '
-                    print(f'\r{empty_message}', end='')
+                empty_message = len(print_message) * ' '
+                print(f'\r{empty_message}', end='')
 
-                    print_message = f'Adding SDSS spectra from Kesseli et al. 2017... {name}'
-                    print(f'\r{print_message}', end='')
+                print_message = f'Adding spectra... {name}'
+                print(f'\r{print_message}', end='')
 
-                    dset = database.create_dataset(f'spectra/kesseli+2017/{name}', data=spdata)
+                dset = database.create_dataset(f'spectra/kesseli+2017/{name}', data=spdata)
 
-                    dset.attrs['name'] = str(name).encode()
-                    dset.attrs['sptype'] = str(sptype).encode()
+                dset.attrs['name'] = str(name).encode()
+                dset.attrs['sptype'] = str(sptype).encode()
 
     empty_message = len(print_message) * ' '
     print(f'\r{empty_message}', end='')
 
-    print_message = 'Adding SDSS spectra from Kesseli et al. 2017... [DONE]'
+    print_message = 'Adding spectra... [DONE]'
     print(f'\r{print_message}')
 
     database.close()

--- a/species/data/spex.py
+++ b/species/data/spex.py
@@ -228,7 +228,7 @@ def add_spex(input_path: str,
             else:
                 distance = (np.nan, np.nan)
 
-            print_message = f'Adding SpeX Prism Spectral Library... {name}'
+            print_message = f'Adding spectra... {name}'
             print(f'\r{print_message:<72}', end='')
 
             dset = database.create_dataset(f'spectra/spex/{name}', data=spdata)
@@ -249,7 +249,7 @@ def add_spex(input_path: str,
             dset.attrs['distance'] = distance[0]  # (pc)
             dset.attrs['distance_error'] = distance[1]  # (pc)
 
-    print_message = 'Adding SpeX Prism Spectral Library... [DONE]'
+    print_message = 'Adding spectra... [DONE]'
     print(f'\r{print_message:<72}')
 
     database.close()

--- a/species/plot/plot_color.py
+++ b/species/plot/plot_color.py
@@ -78,12 +78,13 @@ def plot_color_magnitude(boxes: list,
     reddening : list(tuple(tuple(str, str), tuple(str, float), str, float,
                 tuple(float, float)), None
         Include reddening arrows by providing a list with tuples. Each tuple contains the filter
-        names for the color, the filter name and value of the magnitude, the particle radius (um),
-        and the start position (color, mag) of the arrow in the plot, so ``((filter_color_1,
+        names for the color, the filter name and value of the magnitude, the mean particle radius
+        (um), and the start position (color, mag) of the arrow in the plot, so ``((filter_color_1,
         filter_color_2), (filter_mag, mag_value), composition, radius, (x_pos, y_pos))``. The
-        composition can be either ``'Fe'`` or ``'MgSiO3'`` (both with crystalline structure). Both
-        ``xlim`` and ``ylim`` need to be set for the correct rotation of the reddening label. The
-        parameter is not used if set to ``None``.
+        composition can be either ``'Fe'`` or ``'MgSiO3'`` (both with crystalline structure). A
+        log-normal size distribution is used with the specified mean radius and the geometric
+        standard deviation is fixed to 2. Both ``xlim`` and ``ylim`` need to be set for the correct
+        rotation of the reddening label. The parameter is not used if set to ``None``.
     field_range : tuple(str, str), None
         Range of the discrete colorbar for the field dwarfs. The tuple should contain the lower
         and upper value ('early M', 'late M', 'early L', 'late L', 'early T', 'late T', 'early Y).

--- a/species/read/read_spectrum.py
+++ b/species/read/read_spectrum.py
@@ -90,7 +90,7 @@ class ReadSpectrum:
         except KeyError:
             h5_file.close()
             species_db = database.Database()
-            species_db.add_spectrum(self.spec_library, sptypes)
+            species_db.add_spectra(self.spec_library, sptypes)
             h5_file = h5py.File(self.database, 'r')
 
         list_wavelength = []

--- a/species/util/dust_util.py
+++ b/species/util/dust_util.py
@@ -515,10 +515,10 @@ def interp_powerlaw(inc_phot: List[str],
 @typechecked
 def ism_extinction(av_mag: float,
                    rv_red: float,
-                   wavelengths: np.ndarray) -> np.ndarray:
+                   wavelengths: Union[np.ndarray, List[float], float]) -> np.ndarray:
     """
     Function for calculating the optical and IR extinction with the empirical relation from
-    Cardelli et al. (1989).
+    `Cardelli et al. (1989) <https://ui.adsabs.harvard.edu/abs/1989ApJ...345..245C/abstract>`_.
 
     Parameters
     ----------
@@ -526,14 +526,21 @@ def ism_extinction(av_mag: float,
         Extinction (mag) in the V band.
     rv_red : float
         Reddening in the V band, ``R_V = A_V / E(B-V)``.
-    wavelengths : np.ndarray
-        Array with the wavelengths (um) for which the extinction is calculated.
+    wavelengths : np.ndarray, list(float), float
+        Array or list with the wavelengths (um) for which the extinction is calculated.
+        It is also possible to provide a single value as float.
 
     Returns
     -------
     np.ndarray
         Extinction (mag) at ``wavelengths``.
     """
+
+    if isinstance(wavelengths, float):
+        wavelengths = np.array([wavelengths])
+
+    elif isinstance(wavelengths, list):
+        wavelengths = np.array(wavelengths)
 
     x_wavel = 1./wavelengths
     y_wavel = x_wavel - 1.82

--- a/species/util/plot_util.py
+++ b/species/util/plot_util.py
@@ -346,7 +346,7 @@ def update_labels(param: List[str]) -> List[str]:
 
     if 'line_vrad' in param:
         index = param.index('line_vrad')
-        param[index] = r'v$_\mathregular{r}$ (km s$^{-1}$)'
+        param[index] = r'RV (km s$^{-1}$)'
 
     return param
 


### PR DESCRIPTION
- Support for low-gravity spectra from Bonnefoy et al. (2014) and Allers & Liu (2013).
- Further development of `analysis.compare_spectra` and `plot.plot_comparison`.
- Support for disk parameters in `ReadModel.get_data`.
- Added `leg_param` parameter in `plot_spectrum` for model parameters to include in the legend.
- Changed `Database.add_spectrum` to `Database.add_spectra` (`add_spectrum` will be removed in a future release).
- Maintenance of the code and documentation.