### PR TITLE
Support for fitting blended stars/companions with FitModel

### DIFF
--- a/species/__init__.py
+++ b/species/__init__.py
@@ -73,6 +73,7 @@ from species.util.read_util import (
     get_radius,
     powerlaw_spectrum,
     gaussian_spectrum,
+    update_objectbox,
     update_spectra,
 )
 

--- a/species/analysis/fit_model.py
+++ b/species/analysis/fit_model.py
@@ -440,10 +440,17 @@ def lnprob(
 
 class FitModel:
     """
-    Class for fitting atmospheric model spectra to spectroscopic and/or
-    photometric data, and using Bayesian inference (``UltraNest``,
-    ``MultiNest``, or ``emcee``) to estimate posterior distributions
-    and marginalized likelihoods (i.e. "evidence").
+    Class for fitting atmospheric model spectra to spectra and/or
+    photometric fluxes, and using Bayesian inference (``MultiNest``,
+    ``UltraNest``, or ``emcee``) to estimate the posterior
+    distribution and marginalized likelihood (i.e. "evidence"). The
+    latter is only output from the two nested sampling algorithms.
+    A grid of model spectra is linearly interpolated for each
+    spectrum and photometric flux, while taking into account the
+    filter profile, spectral resolution, and wavelength sampling.
+    The computation time depends mostly on the number of
+    free parameters and the resolution / number of data points
+    of the spectra.
     """
 
     @typechecked
@@ -465,77 +472,104 @@ class FitModel:
         weights: Optional[Dict[str, float]] = None,
     ) -> None:
         """
-        The grid of spectra is linearly interpolated for each
-        photometric point and spectrum while taking into account the
-        filter profile, spectral resolution, and wavelength sampling.
-        Therefore, when fitting spectra from a model grid, the
-        computation time of the interpolation will depend on the
-        wavelength range, spectral resolution, and parameter space of
-        the spectra that are stored in the database.
-
         Parameters
         ----------
         object_name : str
-            Object name as stored in the database with
+            Object name of the companion as stored in the database with
             :func:`~species.data.database.Database.add_object` or
             :func:`~species.data.database.Database.add_companion`.
         model : str
-            Atmospheric model (e.g. 'bt-settl', 'exo-rem', 'planck', or 'powerlaw').
+            Name of the atmospheric model (e.g. 'bt-settl', 'exo-rem',
+            'planck', or 'powerlaw').
         bounds : dict(str, tuple(float, float)), None
-            The boundaries that are used for the uniform priors. Fixing
-            a parameter is possible by providing the same value as
-            lower and upper boundary of the parameter, for example,
-            ``bounds={'logg': (4., 4.)``.
+            The boundaries that are used for the uniform priors.
+            Fixing a parameter is possible by providing the same
+            value as lower and upper boundary of the parameter
+            (e.g. ``bounds={'logg': (4., 4.)``. An explanation of
+            the various parameters can be found below.
 
-            Atmospheric model parameters (e.g. ``model='bt-settl'``):
+            Atmospheric model parameters (e.g. with
+            ``model='bt-settl-cifist'``; see docstring of
+            :meth:`~species.data.database.Database.add_model`
+            for the available model grids):
 
-                 - Boundaries are provided as tuple of two floats. Forexample,
-                   ``bounds={'teff': (1000, 1500.), 'logg': (3.5, 5.), 'radius': (0.8, 1.2)}``.
+               - Boundaries are provided as tuple of two floats. For example,
+                 ``bounds={'teff': (1000, 1500.), 'logg': (3.5, 5.)}``.
 
-                 - The grid boundaries are used if set to ``None``. For example,
-                   ``bounds={'teff': None, 'logg': None}``. The radius range is set to
-                   0.8-1.5 Rjup if the boundary is set to None.
+               - The grid boundaries (i.e. the maximum range) are
+                 adopted as priors if a parameter range is set to
+                 ``None`` or if a mandatory parameter is not included
+                 in the dictionary of ``bounds``. For example,
+                 ``bounds={'teff': (1000., 1500.), 'logg': None}``.
+                 The default range for the radius is
+                 :math:`0.5-5.0~R_\\mathrm{J}`.
 
-            Blackbody emission parameters (``model='planck'``):
+               - It is possible to fit a weighted combination of two
+                 atmospheric parameters from the same model. This
+                 can be useful to fit data of a spectroscopic binary
+                 or to account for atmospheric asymmetries of a single
+                 object. For each atmospheric parameter, a tuple of
+                 two tuples can be provided, for example
+                 ``bounds={'teff': ((1000., 1500.), (1300., 1800.))}``.
+                 Mandatory parameters that are not included are assumed
+                 to be the same for both components. The grid boundaries
+                 are used as parameter range if a component is set to
+                 ``None``. For example, ``bounds={'teff': (None, None),
+                 'logg': (4.0, 4.0), (4.5, 4.5)}`` will use the full
+                 range for :math:`T_\\mathrm{eff}` of both components
+                 and fixes :math:`\\log{g}` to 4.0 and 4.5,
+                 respectively. Only supported by ``run_ultranest`` and
+                 ``run_multinest``.
 
-                 - Parameter boundaries have to be provided for 'teff'
-                   and 'radius'.
+            Blackbody parameters (with ``model='planck'``):
 
-                 - For a single blackbody component, the values are
-                   provided as a tuple with two floats. For example,
-                   ``bounds={'teff': (1000., 2000.), 'radius': (0.8, 1.2)}``.
+               - Parameter boundaries have to be provided for 'teff'
+                 and 'radius'.
 
-                 - For multiple blackbody component, the values are
-                   provided as a list with tuples. For example,
-                   ``bounds={'teff': [(1000., 1400.), (1200., 1600.)],
-                   'radius': [(0.8, 1.5), (1.2, 2.)]}``.
+               - For a single blackbody component, the values are
+                 provided as a tuple with two floats. For example,
+                 ``bounds={'teff': (1000., 2000.),
+                 'radius': (0.8, 1.2)}``.
 
-                 - When fitting multiple blackbody components, a prior
-                   is used which restricts the temperatures and radii
-                   to decreasing and increasing values, respectively,
-                   in the order as provided in ``bounds``.
+               - For multiple blackbody components, the values are
+                 provided as a list with tuples. For example,
+                 ``bounds={'teff': [(1000., 1400.), (1200., 1600.)],
+                 'radius': [(0.8, 1.5), (1.2, 2.)]}``.
+
+               - When fitting multiple blackbody components, an
+                 additional prior is used for restricting the
+                 temperatures and radii to decreasing and increasing
+                 values, respectively, in the order as provided in
+                 ``bounds``.
 
             Power-law spectrum (``model='powerlaw'``):
 
-                 - Parameter boundaries have to be provided for
-                   'log_powerlaw_a', 'log_powerlaw_b', and
-                   'log_powerlaw_c'. For example,
-                   ``bounds={'log_powerlaw_a': (-20., 0.),
-                   'log_powerlaw_b': (-20., 5.), 'log_powerlaw_c':
-                   (-20., 5.)}``.
+               - Parameter boundaries have to be provided for
+                 'log_powerlaw_a', 'log_powerlaw_b', and
+                 'log_powerlaw_c'. For example,
+                 ``bounds={'log_powerlaw_a': (-20., 0.),
+                 'log_powerlaw_b': (-20., 5.), 'log_powerlaw_c':
+                 (-20., 5.)}``.
 
-                 - The spectrum is parametrized as log10(flux) = a + b*log10(wavelength)^c, where
-                   a = log_powerlaw_a, b = log_powerlaw_b, and c = log_powerlaw_c.
+               - The spectrum is parametrized as :math:`\\log10{f} =
+                 a + b*\\log10{\\lambda}^c`, where :math:`a` is
+                 ``log_powerlaw_a``, :math:`b` is ``log_powerlaw_b``,
+                 and :math:`c` is ``log_powerlaw_c``.
 
-                 - Only implemented for fitting photometric fluxes, for example the IR fluxes of a
-                   star with disk. In that way, synthetic photometry can be calculated afterwards
-                   for a different filter. Note that this option assumes that the photometric
-                   fluxes are dominated by continuum emission while spectral lines are ignored.
+               - Only implemented for fitting photometric fluxes, for
+                 example the IR fluxes of a star with disk. In that way,
+                 synthetic photometry can be calculated afterwards for
+                 a different filter. Note that this option assumes that
+                 the photometric fluxes are dominated by continuum
+                 emission while spectral lines are ignored.
 
-                 - The :func:`~species.plot.plot_mcmc.plot_photometry` function can be used to
-                   calculate synthetic photometry and error bars from the posterior distribution.
+               - The :func:`~species.plot.plot_mcmc.plot_mag_posterior`
+                 function can be used for calculating synthetic
+                 photometry and error bars from the posterior
+                 distributions.
 
-                 - Only supported by ``run_ultranest`` and ``run_multinest``.
+               - Only supported by ``run_ultranest`` and
+                 ``run_multinest``.
 
             Calibration parameters:
 
@@ -556,10 +590,15 @@ class FitModel:
 
                  - The errors of the photometric fluxes can be inflated to account for
                    underestimated error bars. The error inflation is relative to the actual flux
-                   and is fitted separately for different filters. The keyword in the ``bounds``
-                   dictionary should be provided in the following format:
-                   ``'Paranal/NACO.Mp_error': (0., 1.)``. In this case, the error of the NACO Mp
-                   flux is inflated up to 100 percent of the actual flux.
+                   and is either fitted separately for a filter, or a single error inflation
+                   is applied to all filters from an instrument. For the first case, the keyword
+                   in the ``bounds`` dictionary should be provided in the following format:
+                   ``'Paranal/NACO.Mp_error': (0., 1.)``. Here, the error of the NACO Mp
+                   flux is inflated up to 100 percent of the actual flux. For the second case,
+                   only the telescope/instrument part of the the filter name should be provided
+                   in the ``bounds`` dictionary, so in the following format:
+                   ``'Paranal/NACO_error': (0., 1.)``. This will increase the errors of all
+                   NACO filters by the same (relative) amount.
 
                  - No calibration parameters are fitted if the spectrum name is not included in
                    ``bounds``.
@@ -708,6 +747,7 @@ class FitModel:
 
         self.object = read_object.ReadObject(object_name)
         self.distance = self.object.get_distance()
+        self.binary = False
 
         if fit_corr is None:
             self.fit_corr = []
@@ -734,7 +774,7 @@ class FitModel:
                     self.bounds[f"radius_{i}"] = bounds["radius"][i]
 
             else:
-                # Fitting a single blackbody compoentn
+                # Fitting a single blackbody component
                 self.n_planck = 1
 
                 self.modelpar = ["teff", "radius"]
@@ -751,57 +791,109 @@ class FitModel:
                 readmodel = read_model.ReadModel(self.model)
                 bounds_grid = readmodel.get_bounds()
 
-                for item in bounds_grid:
-                    if item not in self.bounds:
-                        # Set the parameter boundaries to the grid boundaries if set to None
-                        self.bounds[item] = bounds_grid[item]
+                for key, value in bounds_grid.items():
+
+                    if key not in self.bounds:
+                        # Set the parameter boundaries to the grid
+                        # boundaries if set to None or not found
+                        self.bounds[key] = bounds_grid[key]
+
+                    elif isinstance(self.bounds[key][0], tuple):
+                        self.binary = True
+                        self.bounds[f"{key}_0"] = self.bounds[key][0]
+                        self.bounds[f"{key}_1"] = self.bounds[key][1]
+                        del self.bounds[key]
+
+                    elif self.bounds[key][0] is None and self.bounds[key][1] is None:
+                        self.binary = True
+                        self.bounds[f"{key}_0"] = bounds_grid[key]
+                        self.bounds[f"{key}_1"] = bounds_grid[key]
+                        del self.bounds[key]
+
+                    elif isinstance(self.bounds[key][0], tuple):
+                        self.binary = True
+                        self.bounds[f"{key}_0"] = self.bounds[key][0]
+                        self.bounds[f"{key}_1"] = self.bounds[key][1]
+                        del self.bounds[key]
 
                     else:
-                        if self.bounds[item][0] < bounds_grid[item][0]:
+                        if self.bounds[key][0] < bounds_grid[key][0]:
                             warnings.warn(
-                                f"The lower bound on {item} "
-                                f"({self.bounds[item][0]}) is smaller than "
+                                f"The lower bound on {key} "
+                                f"({self.bounds[key][0]}) is smaller than "
                                 f"the lower bound from the available "
                                 f"{self.model} model grid "
-                                f"({bounds_grid[item][0]}). The lower bound "
-                                f"of the {item} prior will be adjusted to "
-                                f"{bounds_grid[item][0]}."
+                                f"({bounds_grid[key][0]}). The lower bound "
+                                f"of the {key} prior will be adjusted to "
+                                f"{bounds_grid[key][0]}."
                             )
-                            self.bounds[item] = (
-                                bounds_grid[item][0],
-                                self.bounds[item][1],
+                            self.bounds[key] = (
+                                bounds_grid[key][0],
+                                self.bounds[key][1],
                             )
 
-                        if self.bounds[item][1] > bounds_grid[item][1]:
+                        if self.bounds[key][1] > bounds_grid[key][1]:
                             warnings.warn(
-                                f"The upper bound on {item} "
-                                f"({self.bounds[item][1]}) is larger than the "
+                                f"The upper bound on {key} "
+                                f"({self.bounds[key][1]}) is larger than the "
                                 f"upper bound from the available {self.model} "
-                                f"model grid ({bounds_grid[item][1]}). The "
-                                f"bound of the {item} prior will be adjusted "
-                                f"to {bounds_grid[item][1]}."
+                                f"model grid ({bounds_grid[key][1]}). The "
+                                f"bound of the {key} prior will be adjusted "
+                                f"to {bounds_grid[key][1]}."
                             )
-                            self.bounds[item] = (
-                                self.bounds[item][0],
-                                bounds_grid[item][1],
+                            self.bounds[key] = (
+                                self.bounds[key][0],
+                                bounds_grid[key][1],
                             )
+
+                # if self.binary:
+                #     # Check if all parameters are set for two objects
+                #     for key, value in bounds_grid.items():
+                #         if f"{key}_0" not in self.bounds:
+                #             self.bounds[f"{key}_0"] = bounds_grid[key]
+                #             self.bounds[f"{key}_1"] = bounds_grid[key]
+                #             del self.bounds[key]
 
             else:
                 # Set all parameter boundaries to the grid boundaries
                 readmodel = read_model.ReadModel(self.model, None, None)
                 self.bounds = readmodel.get_bounds()
 
-            if "radius" not in self.bounds:
-                self.bounds["radius"] = (0.8, 1.5)
-
-            self.n_planck = 0
-
             self.modelpar = readmodel.get_parameters()
             self.modelpar.append("radius")
+
+            if self.binary:
+                if "radius" in self.bounds:
+                    if isinstance(self.bounds["radius"][0], tuple):
+                        self.bounds["radius_0"] = self.bounds["radius"][0]
+                        self.bounds["radius_1"] = self.bounds["radius"][1]
+                        del self.bounds["radius"]
+
+                else:
+                    self.bounds["radius"] = (0.5, 5.0)
+
+            elif "radius" not in self.bounds:
+                self.bounds["radius"] = (0.5, 5.0)
+
+            self.n_planck = 0
 
             if "disk_teff" in self.bounds and "disk_radius" in self.bounds:
                 self.modelpar.append("disk_teff")
                 self.modelpar.append("disk_radius")
+
+            if self.binary:
+                # Update list of model parameters
+
+                for key in bounds:
+                    if key[:-2] in self.modelpar:
+                        par_index = self.modelpar.index(key[:-2])
+                        self.modelpar[par_index] = key[:-2] + "_0"
+                        self.modelpar.insert(par_index, key[:-2] + "_1")
+
+                self.modelpar.append("spec_weight")
+
+                if "spec_weight" not in self.bounds:
+                    self.bounds["spec_weight"] = (0.0, 1.0)
 
         # Select filters and spectra
 
@@ -838,6 +930,8 @@ class FitModel:
 
         self.objphot = []
         self.modelphot = []
+        self.filter_name = []
+        self.instr_name = []
 
         for item in inc_phot:
             if self.model == "planck":
@@ -855,9 +949,6 @@ class FitModel:
 
                 self.modelphot.append(synphot)
 
-                if f"{item}_error" in self.bounds:
-                    self.modelpar.append(f"{item}_error")
-
             else:
                 # Or interpolate the model grid for each filter
                 print(f"Interpolating {item}...", end="", flush=True)
@@ -868,9 +959,25 @@ class FitModel:
                 self.modelphot.append(readmodel)
                 print(" [DONE]")
 
+            # Add parameter for error inflation
+
+            instr_filt = item.split(".")[0]
+
+            if f"{item}_error" in self.bounds:
+                self.modelpar.append(f"{item}_error")
+
+            elif (
+                f"{instr_filt}_error" in self.bounds
+                and f"{instr_filt}_error" not in self.modelpar
+            ):
+                self.modelpar.append(f"{instr_filt}_error")
+
             # Store the flux and uncertainty for each filter
             obj_phot = self.object.get_photometry(item)
             self.objphot.append(np.array([obj_phot[2], obj_phot[3]]))
+
+            self.filter_name.append(item)
+            self.instr_name.append(instr_filt)
 
         # Include spectroscopic data
 
@@ -893,15 +1000,17 @@ class FitModel:
             for item in self.spectrum:
                 if item in self.fit_corr:
                     if self.spectrum[item][1] is not None:
-                        warnings.warn(f"There is a covariance matrix included "
-                                      f"with the {item} data of "
-                                      f"{object_name} so it is not needed to "
-                                      f"model the covariances with a "
-                                      f"Gaussian process. Want to test the "
-                                      f"Gaussian process nonetheless? Please "
-                                      f"overwrite the data of {object_name} "
-                                      f"with add_object while setting the "
-                                      f"path to the covariance data to None.")
+                        warnings.warn(
+                            f"There is a covariance matrix included "
+                            f"with the {item} data of "
+                            f"{object_name} so it is not needed to "
+                            f"model the covariances with a "
+                            f"Gaussian process. Want to test the "
+                            f"Gaussian process nonetheless? Please "
+                            f"overwrite the data of {object_name} "
+                            f"with add_object while setting the "
+                            f"path to the covariance data to None."
+                        )
 
                         self.fit_corr.remove(item)
 
@@ -953,6 +1062,18 @@ class FitModel:
         if self.model not in ["planck", "powerlaw"]:
             readmodel = read_model.ReadModel(self.model)
             self.param_interp = readmodel.get_parameters()
+
+            if self.binary:
+                param_tmp = self.param_interp.copy()
+
+                self.param_interp = []
+                for item in param_tmp:
+                    if f"{item}_0" in self.modelpar and f"{item}_1" in self.modelpar:
+                        self.param_interp.append(f"{item}_0")
+                        self.param_interp.append(f"{item}_1")
+
+                    else:
+                        self.param_interp.append(item)
 
         else:
             self.param_interp = None
@@ -1365,13 +1486,14 @@ class FitModel:
         # Initilize dictionaries for different parameter types
 
         spec_scaling = {}
+        phot_scaling = {}
         err_scaling = {}
         corr_len = {}
         corr_amp = {}
         dust_param = {}
         disk_param = {}
-        param_dict = {}
         veil_param = {}
+        param_dict = {}
 
         for item in self.bounds:
             # Add the parameters from the params to their dictionaries
@@ -1387,6 +1509,12 @@ class FitModel:
 
             elif item[:9] == "corr_amp_" and item[9:] in self.spectrum:
                 corr_amp[item[9:]] = params[self.cube_index[item]]
+
+            elif item[-6:] == "_error" and item[:-6] in self.filter_name:
+                phot_scaling[item[:-6]] = params[self.cube_index[item]]
+
+            elif item[-6:] == "_error" and item[:-6] in self.instr_name:
+                phot_scaling[item[:-6]] = params[self.cube_index[item]]
 
             elif item[:8] == "lognorm_":
                 dust_param[item] = params[self.cube_index[item]]
@@ -1411,6 +1539,9 @@ class FitModel:
 
             elif item == "veil_ref":
                 veil_param["veil_ref"] = params[self.cube_index[item]]
+
+            elif item == "spec_weight":
+                pass
 
             else:
                 param_dict[item] = params[self.cube_index[item]]
@@ -1445,6 +1576,9 @@ class FitModel:
             elif item == "disk_radius":
                 disk_param["radius"] = self.fix_param[item]
 
+            elif item == "spec_weight":
+                pass
+
             else:
                 param_dict[item] = self.fix_param[item]
 
@@ -1467,12 +1601,26 @@ class FitModel:
             param_dict["distance"] = self.distance[0]
 
         elif self.model != "powerlaw":
-            flux_scaling = (param_dict["radius"] * constants.R_JUP) ** 2 / (
-                self.distance[0] * constants.PARSEC
-            ) ** 2
+            if "radius_0" in param_dict and "radius_1" in param_dict:
+                flux_scaling_0 = (param_dict["radius_0"] * constants.R_JUP) ** 2 / (
+                    self.distance[0] * constants.PARSEC
+                ) ** 2
 
-            # The scaling is applied manually because of the interpolation
-            del param_dict["radius"]
+                flux_scaling_1 = (param_dict["radius_1"] * constants.R_JUP) ** 2 / (
+                    self.distance[0] * constants.PARSEC
+                ) ** 2
+
+                # The scaling is applied manually because of the interpolation
+                del param_dict["radius_0"]
+                del param_dict["radius_1"]
+
+            else:
+                flux_scaling = (param_dict["radius"] * constants.R_JUP) ** 2 / (
+                    self.distance[0] * constants.PARSEC
+                ) ** 2
+
+                # The scaling is applied manually because of the interpolation
+                del param_dict["radius"]
 
         for item in self.spectrum:
             if item not in spec_scaling:
@@ -1550,10 +1698,46 @@ class FitModel:
                 )[0]
 
             else:
-                phot_flux = self.modelphot[i].spectrum_interp(
-                    list(param_dict.values())
-                )[0][0]
-                phot_flux *= flux_scaling
+                if self.binary:
+                    # Star 0
+
+                    param_0 = read_util.binary_to_single(param_dict, 0)
+
+                    phot_flux_0 = self.modelphot[i].spectrum_interp(
+                        list(param_0.values())
+                    )[0][0]
+
+                    if "radius" in self.modelpar:
+                        phot_flux_0 *= flux_scaling
+                    elif "radius_0" in self.modelpar:
+                        phot_flux_0 *= flux_scaling_0
+
+                    # Star 1
+
+                    param_1 = read_util.binary_to_single(param_dict, 1)
+
+                    phot_flux_1 = self.modelphot[i].spectrum_interp(
+                        list(param_1.values())
+                    )[0][0]
+
+                    if "radius" in self.modelpar:
+                        phot_flux_1 *= flux_scaling
+                    elif "radius_1" in self.modelpar:
+                        phot_flux_1 *= flux_scaling_1
+
+                    # Weighted flux of two stars
+
+                    phot_flux = (
+                        params[self.cube_index["spec_weight"]] * phot_flux_0
+                        + (1.0 - params[self.cube_index["spec_weight"]]) * phot_flux_1
+                    )
+
+                else:
+                    phot_flux = self.modelphot[i].spectrum_interp(
+                        list(param_dict.values())
+                    )[0][0]
+
+                    phot_flux *= flux_scaling
 
             if disk_param:
                 phot_tmp = self.diskphot[i].spectrum_interp([disk_param["teff"]])[0][0]
@@ -1593,10 +1777,16 @@ class FitModel:
             if obj_item.ndim == 1:
                 phot_var = obj_item[1] ** 2
 
-                if self.model == "powerlaw" and f"{phot_filter}_error" in param_dict:
-                    phot_var += (
-                        param_dict[f"{phot_filter}_error"] ** 2 * obj_item[0] ** 2
-                    )
+                # Get the telescope/instrument name
+                instr_check = phot_filter.split(".")[0]
+
+                if phot_filter in phot_scaling:
+                    # Inflate photometric error for filter
+                    phot_var += phot_scaling[phot_filter] ** 2 * obj_item[0] ** 2
+
+                elif instr_check in phot_scaling:
+                    # Inflate photometric error for instrument
+                    phot_var += phot_scaling[instr_check] ** 2 * obj_item[0] ** 2
 
                 ln_like += -0.5 * weight * (obj_item[0] - phot_flux) ** 2 / phot_var
 
@@ -1647,12 +1837,50 @@ class FitModel:
 
             else:
                 # Interpolate the model spectrum from the grid
-                model_flux = self.modelspec[i].spectrum_interp(
-                    list(param_dict.values())
-                )[0, :]
 
-                # Scale the spectrum by (radius/distance)^2
-                model_flux *= flux_scaling
+                if self.binary:
+                    # Star 1
+
+                    param_0 = read_util.binary_to_single(param_dict, 0)
+
+                    model_flux_0 = self.modelspec[i].spectrum_interp(
+                        list(param_0.values())
+                    )[0, :]
+
+                    # Scale the spectrum by (radius/distance)^2
+                    if "radius" in self.modelpar:
+                        model_flux_0 *= flux_scaling
+                    elif "radius_1" in self.modelpar:
+                        model_flux_0 *= flux_scaling_1
+
+                    # Star 2
+
+                    param_1 = read_util.binary_to_single(param_dict, 1)
+
+                    model_flux_1 = self.modelspec[i].spectrum_interp(
+                        list(param_1.values())
+                    )[0, :]
+
+                    # Scale the spectrum by (radius/distance)^2
+                    if "radius" in self.modelpar:
+                        model_flux_1 *= flux_scaling
+                    elif "radius_1" in self.modelpar:
+                        model_flux_1 *= flux_scaling_1
+
+                    # Weighted flux of two stars
+
+                    model_flux = (
+                        params[self.cube_index["spec_weight"]] * model_flux_0
+                        + (1.0 - params[self.cube_index["spec_weight"]]) * model_flux_1
+                    )
+
+                else:
+                    model_flux = self.modelspec[i].spectrum_interp(
+                        list(param_dict.values())
+                    )[0, :]
+
+                    # Scale the spectrum by (radius/distance)^2
+                    model_flux *= flux_scaling
 
             # Veiling
             if (

--- a/species/analysis/fit_model.py
+++ b/species/analysis/fit_model.py
@@ -849,14 +849,6 @@ class FitModel:
                                 bounds_grid[key][1],
                             )
 
-                # if self.binary:
-                #     # Check if all parameters are set for two objects
-                #     for key, value in bounds_grid.items():
-                #         if f"{key}_0" not in self.bounds:
-                #             self.bounds[f"{key}_0"] = bounds_grid[key]
-                #             self.bounds[f"{key}_1"] = bounds_grid[key]
-                #             del self.bounds[key]
-
             else:
                 # Set all parameter boundaries to the grid boundaries
                 readmodel = read_model.ReadModel(self.model, None, None)
@@ -1710,8 +1702,11 @@ class FitModel:
                         list(param_0.values())
                     )[0][0]
 
+                    # Scale the spectrum by (radius/distance)^2
+
                     if "radius" in self.modelpar:
                         phot_flux_0 *= flux_scaling
+
                     elif "radius_0" in self.modelpar:
                         phot_flux_0 *= flux_scaling_0
 
@@ -1723,8 +1718,11 @@ class FitModel:
                         list(param_1.values())
                     )[0][0]
 
+                    # Scale the spectrum by (radius/distance)^2
+
                     if "radius" in self.modelpar:
                         phot_flux_1 *= flux_scaling
+
                     elif "radius_1" in self.modelpar:
                         phot_flux_1 *= flux_scaling_1
 
@@ -1851,10 +1849,12 @@ class FitModel:
                     )[0, :]
 
                     # Scale the spectrum by (radius/distance)^2
+
                     if "radius" in self.modelpar:
                         model_flux_0 *= flux_scaling
+
                     elif "radius_1" in self.modelpar:
-                        model_flux_0 *= flux_scaling_1
+                        model_flux_0 *= flux_scaling_0
 
                     # Star 2
 
@@ -1865,8 +1865,10 @@ class FitModel:
                     )[0, :]
 
                     # Scale the spectrum by (radius/distance)^2
+
                     if "radius" in self.modelpar:
                         model_flux_1 *= flux_scaling
+
                     elif "radius_1" in self.modelpar:
                         model_flux_1 *= flux_scaling_1
 

--- a/species/analysis/fit_model.py
+++ b/species/analysis/fit_model.py
@@ -518,8 +518,11 @@ class FitModel:
                  'logg': (4.0, 4.0), (4.5, 4.5)}`` will use the full
                  range for :math:`T_\\mathrm{eff}` of both components
                  and fixes :math:`\\log{g}` to 4.0 and 4.5,
-                 respectively. Only supported by ``run_ultranest`` and
-                 ``run_multinest``.
+                 respectively. The ``spec_weight`` parameter is
+                 automatically included in the fit, as it sets the
+                 weight of the two components. Modeling blended data
+                 is only supported by ``run_ultranest`` and
+                 ``run_multinest``. 
 
             Blackbody parameters (with ``model='planck'``):
 

--- a/species/analysis/retrieval.py
+++ b/species/analysis/retrieval.py
@@ -686,7 +686,10 @@ class AtmosphericRetrieval:
             smoothing the sampled temperature nodes of the P-T profile.
             Only required with `pt_profile='free'` or
             `pt_profile='monotonic'`. The argument should be given as
-            log10(P/bar) with the default value set to 0.3 dex.
+            log10(P/bar) with the default value set to 0.3 dex. The
+            ``pt_smooth`` parameter can also be included in ``bounds``,
+            in which case the value is fitted and the ``pt_smooth``
+            argument of the ``run_multinest`` is ignored.
         check_flux : float, None
             Relative tolerance for enforcing a constant bolometric
             flux at all pressures layers. To use this parameter, the

--- a/species/plot/plot_color.py
+++ b/species/plot/plot_color.py
@@ -48,7 +48,7 @@ def plot_color_magnitude(
     ylim: Optional[Tuple[float, float]] = None,
     offset: Optional[Tuple[float, float]] = None,
     legend: Optional[Union[str, dict, Tuple[float, float]]] = "upper left",
-    output: str = "color-magnitude.pdf",
+    output: Optional[str] = "color-magnitude.pdf",
 ) -> None:
     """
     Function for creating a color-magnitude diagram.
@@ -822,7 +822,7 @@ def plot_color_color(
     offset: Optional[Tuple[float, float]] = None,
     legend: Optional[Union[str, dict, Tuple[float, float]]] = "upper left",
     figsize: Optional[Tuple[float, float]] = (4.0, 4.3),
-    output: str = "color-color.pdf",
+    output: Optional[str] = "color-color.pdf",
 ) -> None:
     """
     Function for creating a color-color diagram.

--- a/species/plot/plot_color.py
+++ b/species/plot/plot_color.py
@@ -117,7 +117,8 @@ def plot_color_magnitude(
     legend : str, tuple(float, float), dict, None
         Legend position or keyword arguments. No legend is shown if set to ``None``.
     output : str
-        Output filename.
+        Output filename for the plot. The plot is shown in an
+        interface window if the argument is set to ``None``.
 
     Returns
     -------
@@ -749,7 +750,10 @@ def plot_color_magnitude(
                     **kwargs,
                 )
 
-    print(f"Plotting color-magnitude diagram: {output}...", end="", flush=True)
+    if output is None:
+        print("Plotting color-magnitude diagram...", end="", flush=True)
+    else:
+        print(f"Plotting color-magnitude diagram: {output}...", end="", flush=True)
 
     if legend is not None:
         handles, labels = ax1.get_legend_handles_labels()
@@ -767,7 +771,11 @@ def plot_color_magnitude(
                 numpoints=1,
             )
 
-    plt.savefig(os.getcwd() + "/" + output, bbox_inches="tight")
+    if output is None:
+        plt.show()
+    else:
+        plt.savefig(os.getcwd() + "/" + output, bbox_inches="tight")
+
     plt.clf()
     plt.close()
 
@@ -872,7 +880,8 @@ def plot_color_color(
     figsize : tuple(float, float)
         Figure size.
     output : str
-        Output filename.
+        Output filename for the plot. The plot is shown in an
+        interface window if the argument is set to ``None``.
 
     Returns
     -------
@@ -1437,7 +1446,10 @@ def plot_color_color(
                     **kwargs,
                 )
 
-    print(f"Plotting color-color diagram: {output}...", end="", flush=True)
+    if output is None:
+        print("Plotting color-color diagram...", end="", flush=True)
+    else:
+        print(f"Plotting color-color diagram: {output}...", end="", flush=True)
 
     handles, labels = ax1.get_legend_handles_labels()
 
@@ -1457,7 +1469,11 @@ def plot_color_color(
                 numpoints=1,
             )
 
-    plt.savefig(os.getcwd() + "/" + output, bbox_inches="tight")
+    if output is None:
+        plt.show()
+    else:
+        plt.savefig(os.getcwd() + "/" + output, bbox_inches="tight")
+
     plt.clf()
     plt.close()
 

--- a/species/plot/plot_comparison.py
+++ b/species/plot/plot_comparison.py
@@ -29,7 +29,7 @@ def plot_statistic(
     title: Optional[str] = None,
     offset: Optional[Tuple[float, float]] = None,
     figsize: Optional[Tuple[float, float]] = (4.0, 2.5),
-    output: str = "statistic.pdf",
+    output: Optional[str] = "statistic.pdf",
 ):
     """
     Function for plotting the goodness-of-fit statistic of the empirical spectral comparison.
@@ -199,7 +199,7 @@ def plot_empirical_spectra(
     title: Optional[str] = None,
     offset: Optional[Tuple[float, float]] = None,
     figsize: Optional[Tuple[float, float]] = (4.0, 2.5),
-    output: str = "empirical.pdf",
+    output: Optional[str] = "empirical.pdf",
 ):
     """
     Function for plotting the results from the empirical spectrum comparison.
@@ -446,7 +446,7 @@ def plot_grid_statistic(
     title: Optional[str] = None,
     offset: Optional[Tuple[float, float]] = None,
     figsize: Optional[Tuple[float, float]] = (4.0, 2.5),
-    output: str = "grid_statistic.pdf",
+    output: Optional[str] = "grid_statistic.pdf",
 ):
     """
     Function for plotting the results from the empirical spectrum comparison.

--- a/species/plot/plot_comparison.py
+++ b/species/plot/plot_comparison.py
@@ -50,7 +50,8 @@ def plot_statistic(
     figsize : tuple(float, float)
         Figure size.
     output : str
-        Output filename.
+        Output filename for the plot. The plot is shown in an
+        interface window if the argument is set to ``None``.
 
     Returns
     -------
@@ -58,7 +59,10 @@ def plot_statistic(
         None
     """
 
-    print(f"Plotting goodness-of-fit statistic: {output}...", end="")
+    if output is None:
+        print("Plotting goodness-of-fit statistic...", end="")
+    else:
+        print(f"Plotting goodness-of-fit statistic: {output}...", end="")
 
     config_file = os.path.join(os.getcwd(), "species_config.ini")
 
@@ -171,7 +175,11 @@ def plot_statistic(
         markeredgecolor="darkgray",
     )
 
-    plt.savefig(os.getcwd() + "/" + output, bbox_inches="tight")
+    if output is None:
+        plt.show()
+    else:
+        plt.savefig(os.getcwd() + "/" + output, bbox_inches="tight")
+
     plt.clf()
     plt.close()
 
@@ -222,7 +230,8 @@ def plot_empirical_spectra(
     figsize : tuple(float, float)
         Figure size.
     output : str
-        Output filename.
+        Output filename for the plot. The plot is shown in an
+        interface window if the argument is set to ``None``.
 
     Returns
     -------
@@ -230,7 +239,10 @@ def plot_empirical_spectra(
         None
     """
 
-    print(f"Plotting empirical spectra comparison: {output}...", end="")
+    if output is None:
+        print("Plotting empirical spectra comparison...", end="")
+    else:
+        print(f"Plotting empirical spectra comparison: {output}...", end="")
 
     if flux_offset is None:
         flux_offset = 0.0
@@ -412,7 +424,11 @@ def plot_empirical_spectra(
                 ha="left",
             )
 
-    plt.savefig(os.getcwd() + "/" + output, bbox_inches="tight")
+    if output is None:
+        plt.show()
+    else:
+        plt.savefig(os.getcwd() + "/" + output, bbox_inches="tight")
+
     plt.clf()
     plt.close()
 
@@ -453,7 +469,8 @@ def plot_grid_statistic(
     figsize : tuple(float, float)
         Figure size.
     output : str
-        Output filename.
+        Output filename for the plot. The plot is shown in an
+        interface window if the argument is set to ``None``.
 
     Returns
     -------
@@ -461,7 +478,10 @@ def plot_grid_statistic(
         None
     """
 
-    print(f"Plotting goodness-of-fit of model grid: {output}...", end="")
+    if output is None:
+        print("Plotting goodness-of-fit of model grid...", end="")
+    else:
+        print(f"Plotting goodness-of-fit of model grid: {output}...", end="")
 
     config_file = os.path.join(os.getcwd(), "species_config.ini")
 
@@ -731,7 +751,11 @@ def plot_grid_statistic(
         # ax.annotate(par_text, (best_param[0]+50., best_param[1]), ha='left', va='center',
         #             color='white', fontsize=12.)
 
-    plt.savefig(os.getcwd() + "/" + output, bbox_inches="tight")
+    if output is None:
+        plt.show()
+    else:
+        plt.savefig(os.getcwd() + "/" + output, bbox_inches="tight")
+
     plt.clf()
     plt.close()
 

--- a/species/plot/plot_mcmc.py
+++ b/species/plot/plot_mcmc.py
@@ -41,7 +41,8 @@ def plot_walkers(
     offset : tuple(float, float), None
         Offset of the x- and y-axis label. Default values are used if set to ``None``.
     output : str
-        Output filename.
+        Output filename for the plot. The plot is shown in an
+        interface window if the argument is set to ``None``.
 
     Returns
     -------
@@ -49,7 +50,10 @@ def plot_walkers(
         None
     """
 
-    print(f"Plotting walkers: {output}...", end="", flush=True)
+    if output is None:
+        print("Plotting walkers...", end="", flush=True)
+    else:
+        print(f"Plotting walkers: {output}...", end="", flush=True)
 
     mpl.rcParams["font.serif"] = ["Bitstream Vera Serif"]
     mpl.rcParams["font.family"] = "serif"
@@ -166,7 +170,11 @@ def plot_walkers(
         for j in range(samples.shape[0]):
             ax.plot(samples[j, :, i], ls="-", lw=0.5, color="black", alpha=0.5)
 
-    plt.savefig(os.getcwd() + "/" + output, bbox_inches="tight")
+    if output is None:
+        plt.show()
+    else:
+        plt.savefig(os.getcwd() + "/" + output, bbox_inches="tight")
+
     plt.clf()
     plt.close()
 
@@ -224,7 +232,8 @@ def plot_posterior(
     inc_loglike : bool
         Include the log10 of the likelihood as additional parameter in the corner plot.
     output : str
-        Output filename.
+        Output filename for the plot. The plot is shown in an
+        interface window if the argument is set to ``None``.
 
     Returns
     -------
@@ -470,7 +479,10 @@ def plot_posterior(
             # (um) -> (nm)
             box.samples[:, param_index] *= 1e3
 
-    print(f"Plotting the posterior: {output}...", end="", flush=True)
+    if output is None:
+        print("Plotting the posterior...", end="", flush=True)
+    else:
+        print(f"Plotting the posterior: {output}...", end="", flush=True)
 
     if "H2O" in box.parameters:
         samples = np.column_stack((samples, c_h_ratio, o_h_ratio, c_o_ratio))
@@ -771,7 +783,11 @@ def plot_posterior(
     if title:
         fig.suptitle(title, y=1.02, fontsize=16)
 
-    plt.savefig(os.getcwd() + "/" + output, bbox_inches="tight")
+    if output is None:
+        plt.show()
+    else:
+        plt.savefig(os.getcwd() + "/" + output, bbox_inches="tight")
+
     plt.clf()
     plt.close()
 
@@ -801,7 +817,8 @@ def plot_mag_posterior(
     xlim : tuple(float, float), None
         Axis limits. Automatically set if set to ``None``.
     output : str
-        Output filename.
+        Output filename for the plot. The plot is shown in an
+        interface window if the argument is set to ``None``.
 
     Returns
     -------
@@ -818,7 +835,10 @@ def plot_mag_posterior(
 
     samples = species_db.get_mcmc_photometry(tag, filter_name, burnin)
 
-    print(f"Plotting photometry samples: {output}...", end="", flush=True)
+    if output is None:
+        print("Plotting photometry samples...", end="", flush=True)
+    else:
+        print(f"Plotting photometry samples: {output}...", end="", flush=True)
 
     fig = corner.corner(
         samples,
@@ -869,7 +889,11 @@ def plot_mag_posterior(
 
     ax.get_xaxis().set_label_coords(0.5, -0.26)
 
-    plt.savefig(os.getcwd() + "/" + output, bbox_inches="tight")
+    if output is None:
+        plt.show()
+    else:
+        plt.savefig(os.getcwd() + "/" + output, bbox_inches="tight")
+
     plt.clf()
     plt.close()
 
@@ -900,7 +924,8 @@ def plot_size_distributions(
     offset : tuple(float, float), None
         Offset of the x- and y-axis label. Default values are used if set to ``None``.
     output : str
-        Output filename.
+        Output filename for the plot. The plot is shown in an
+        interface window if the argument is set to ``None``.
 
     Returns
     -------
@@ -908,7 +933,10 @@ def plot_size_distributions(
         None
     """
 
-    print(f"Plotting size distributions: {output}...", end="", flush=True)
+    if output is None:
+        print("Plotting size distributions...", end="", flush=True)
+    else:
+        print(f"Plotting size distributions: {output}...", end="", flush=True)
 
     if burnin is None:
         burnin = 0
@@ -1036,7 +1064,11 @@ def plot_size_distributions(
 
         ax.plot(radii, dn_grains / r_width, ls="-", lw=0.5, color="black", alpha=0.5)
 
-    plt.savefig(os.getcwd() + "/" + output, bbox_inches="tight")
+    if output is None:
+        plt.show()
+    else:
+        plt.savefig(os.getcwd() + "/" + output, bbox_inches="tight")
+
     plt.clf()
     plt.close()
 
@@ -1078,7 +1110,8 @@ def plot_extinction(
     offset : tuple(float, float), None
         Offset of the x- and y-axis label. Default values are used if set to ``None``.
     output : str
-        Output filename.
+        Output filename for the plot. The plot is shown in an
+        interface window if the argument is set to ``None``.
 
     Returns
     -------
@@ -1291,9 +1324,16 @@ def plot_extinction(
     else:
         raise ValueError("The SamplesBox does not contain extinction parameters.")
 
-    print(f"Plotting extinction: {output}...", end="", flush=True)
+    if output is None:
+        print("Plotting extinction...", end="", flush=True)
+    else:
+        print(f"Plotting extinction: {output}...", end="", flush=True)
 
-    plt.savefig(os.getcwd() + "/" + output, bbox_inches="tight")
+    if output is None:
+        plt.show()
+    else:
+        plt.savefig(os.getcwd() + "/" + output, bbox_inches="tight")
+
     plt.clf()
     plt.close()
 

--- a/species/plot/plot_mcmc.py
+++ b/species/plot/plot_mcmc.py
@@ -27,7 +27,7 @@ def plot_walkers(
     tag: str,
     nsteps: Optional[int] = None,
     offset: Optional[Tuple[float, float]] = None,
-    output: str = "walkers.pdf",
+    output: Optional[str] = "walkers.pdf",
 ) -> None:
     """
     Function to plot the step history of the walkers.
@@ -195,7 +195,7 @@ def plot_posterior(
     inc_mass: bool = False,
     inc_pt_param: bool = False,
     inc_loglike: bool = False,
-    output: str = "posterior.pdf",
+    output: Optional[str] = "posterior.pdf",
 ) -> None:
     """
     Function to plot the posterior distribution of the fitted parameters.
@@ -800,7 +800,7 @@ def plot_mag_posterior(
     filter_name: str,
     burnin: int = None,
     xlim: Tuple[float, float] = None,
-    output: str = "mag_posterior.pdf",
+    output: Optional[str] = "mag_posterior.pdf",
 ) -> np.ndarray:
     """
     Function to plot the posterior distribution of the synthetic
@@ -908,7 +908,7 @@ def plot_size_distributions(
     burnin: Optional[int] = None,
     random: Optional[int] = None,
     offset: Optional[Tuple[float, float]] = None,
-    output: str = "size_distributions.pdf",
+    output: Optional[str] = "size_distributions.pdf",
 ) -> None:
     """
     Function to plot random samples of the log-normal or power-law size distributions.
@@ -1085,7 +1085,7 @@ def plot_extinction(
     xlim: Optional[Tuple[float, float]] = None,
     ylim: Optional[Tuple[float, float]] = None,
     offset: Optional[Tuple[float, float]] = None,
-    output: str = "extinction.pdf",
+    output: Optional[str] = "extinction.pdf",
 ) -> None:
     """
     Function to plot random samples of the extinction, either from fitting a size distribution

--- a/species/plot/plot_mcmc.py
+++ b/species/plot/plot_mcmc.py
@@ -901,6 +901,7 @@ def plot_mag_posterior(
 
     return samples
 
+
 @typechecked
 def plot_size_distributions(
     tag: str,

--- a/species/plot/plot_retrieval.py
+++ b/species/plot/plot_retrieval.py
@@ -2,6 +2,7 @@
 Module for plotting atmospheric retrieval results.
 """
 
+import os
 import warnings
 
 from typing import Optional, Tuple

--- a/species/plot/plot_retrieval.py
+++ b/species/plot/plot_retrieval.py
@@ -51,7 +51,8 @@ def plot_pt_profile(
     offset : tuple(float, float), None
         Offset of the x- and y-axis label. Default values are used if set to ``None``.
     output : str
-        Output filename.
+        Output filename for the plot. The plot is shown in an
+        interface window if the argument is set to ``None``.
     radtrans : read_radtrans.ReadRadtrans, None
         Instance of :class:`~species.read.read_radtrans.ReadRadtrans`. Not used if set to ``None``.
     extra_axis : str, None
@@ -66,7 +67,10 @@ def plot_pt_profile(
         None
     """
 
-    print(f"Plotting the P-T profiles: {output}...", end="", flush=True)
+    if output is None:
+        print("Plotting the P-T profiles...", end="", flush=True)
+    else:
+        print(f"Plotting the P-T profiles: {output}...", end="", flush=True)
 
     cloud_species = ["Fe(c)", "MgSiO3(c)", "Al2O3(c)", "Na2S(c)", "KCl(c)"]
 
@@ -601,7 +605,11 @@ def plot_pt_profile(
                 "contain a ReadRadtrans object."
             )
 
-    plt.savefig(output, bbox_inches="tight")
+    if output is None:
+        plt.show()
+    else:
+        plt.savefig(os.getcwd() + "/" + output, bbox_inches="tight")
+
     plt.clf()
     plt.close()
 
@@ -625,7 +633,8 @@ def plot_opacities(
     offset : tuple(float, float), None
         Offset of the x- and y-axis label. Default values are used if set to ``None``.
     output : str
-        Output filename.
+        Output filename for the plot. The plot is shown in an
+        interface window if the argument is set to ``None``.
     radtrans : read_radtrans.ReadRadtrans
         Instance of :class:`~species.read.read_radtrans.ReadRadtrans`. The parameter is not used if
         set to ``None``.
@@ -636,7 +645,10 @@ def plot_opacities(
         None
     """
 
-    print(f"Plotting opacities: {output}...", end="", flush=True)
+    if output:
+        print("Plotting opacities...", end="", flush=True)
+    else:
+        print(f"Plotting opacities: {output}...", end="", flush=True)
 
     species_db = database.Database()
     box = species_db.get_samples(tag)
@@ -875,7 +887,11 @@ def plot_opacities(
     ax3.set_yscale("log")
     ax4.set_yscale("log")
 
-    plt.savefig(output, bbox_inches="tight")
+    if output is None:
+        plt.show()
+    else:
+        plt.savefig(os.getcwd() + "/" + output, bbox_inches="tight")
+
     plt.clf()
     plt.close()
 
@@ -902,7 +918,8 @@ def plot_clouds(
     offset : tuple(float, float), None
         Offset of the x- and y-axis label. Default values are used if set to ``None``.
     output : str
-        Output filename.
+        Output filename for the plot. The plot is shown in an
+        interface window if the argument is set to ``None``.
     radtrans : read_radtrans.ReadRadtrans, None
         Instance of :class:`~species.read.read_radtrans.ReadRadtrans`. Not used if set to ``None``.
     composition : str
@@ -929,7 +946,10 @@ def plot_clouds(
             f"sample contains the following parameters: {list(median.keys())}"
         )
 
-    print(f"Plotting {composition} clouds: {output}...", end="", flush=True)
+    if output is None:
+        print("Plotting {composition} clouds...", end="", flush=True)
+    else:
+        print(f"Plotting {composition} clouds: {output}...", end="", flush=True)
 
     mpl.rcParams["font.serif"] = ["Bitstream Vera Serif"]
     mpl.rcParams["font.family"] = "serif"
@@ -1072,7 +1092,11 @@ def plot_clouds(
     ax1.set_yscale("log")
     ax2.set_yscale("log")
 
-    plt.savefig(output, bbox_inches="tight")
+    if output is None:
+        plt.show()
+    else:
+        plt.savefig(os.getcwd() + "/" + output, bbox_inches="tight")
+
     plt.clf()
     plt.close()
 

--- a/species/plot/plot_retrieval.py
+++ b/species/plot/plot_retrieval.py
@@ -30,7 +30,7 @@ def plot_pt_profile(
     xlim: Optional[Tuple[float, float]] = None,
     ylim: Optional[Tuple[float, float]] = None,
     offset: Optional[Tuple[float, float]] = None,
-    output: str = "pt_profile.pdf",
+    output: Optional[str] = "pt_profile.pdf",
     radtrans: Optional[read_radtrans.ReadRadtrans] = None,
     extra_axis: Optional[str] = None,
     rad_conv_bound: bool = False,
@@ -622,7 +622,7 @@ def plot_opacities(
     tag: str,
     radtrans: read_radtrans.ReadRadtrans,
     offset: Optional[Tuple[float, float]] = None,
-    output: str = "opacities.pdf",
+    output: Optional[str] = "opacities.pdf",
 ) -> None:
     """
     Function to plot the line and continuum opacity structure from the median posterior samples.
@@ -903,7 +903,7 @@ def plot_opacities(
 def plot_clouds(
     tag: str,
     offset: Optional[Tuple[float, float]] = None,
-    output: str = "clouds.pdf",
+    output: Optional[str] = "clouds.pdf",
     radtrans: Optional[read_radtrans.ReadRadtrans] = None,
     composition: str = "MgSiO3",
 ) -> None:

--- a/species/plot/plot_spectrum.py
+++ b/species/plot/plot_spectrum.py
@@ -43,7 +43,7 @@ def plot_spectrum(
     figsize: Optional[Tuple[float, float]] = (10.0, 5.0),
     object_type: str = "planet",
     quantity: str = "flux density",
-    output: str = "spectrum.pdf",
+    output: Optional[str] = "spectrum.pdf",
     leg_param: Optional[List[str]] = None,
 ):
     """
@@ -109,7 +109,8 @@ def plot_spectrum(
     quantity: str
         The quantity of the y-axis ('flux density', 'flux', or 'magnitude').
     output : str
-        Output filename.
+        Output filename for the plot. The plot is shown in an
+        interface window if the argument is set to ``None``.
     leg_param : list(str), None
         List with the parameters to include in the legend of the model spectra. Apart from
         atmospheric parameters (e.g. 'teff', 'logg', 'radius') also parameters such as 'mass'
@@ -1015,7 +1016,10 @@ def plot_spectrum(
     if filters is not None:
         ax2.set_ylim(0.0, 1.1)
 
-    print(f"Plotting spectrum: {output}...", end="", flush=True)
+    if output is None:
+        print("Plotting spectrum...", end="", flush=True)
+    else:
+        print(f"Plotting spectrum: {output}...", end="", flush=True)
 
     if title is not None:
         if filters:
@@ -1145,7 +1149,11 @@ def plot_spectrum(
     # ax1.text(1.26, 0.58, 'VLT/SPHERE', ha='center', va='center', fontsize=8., color='slateblue', rotation=43.)
     # ax1.text(2.5, 1.28, 'VLT/SINFONI', ha='left', va='center', fontsize=8., color='darkgray')
 
-    plt.savefig(os.getcwd() + "/" + output, bbox_inches="tight")
+    if output is None:
+        plt.show()
+    else:
+        plt.savefig(os.getcwd() + "/" + output, bbox_inches="tight")
+
     plt.clf()
     plt.close()
 

--- a/species/read/read_radtrans.py
+++ b/species/read/read_radtrans.py
@@ -108,7 +108,7 @@ class ReadRadtrans:
         self.cloud_wavel = cloud_wavel
 
         # Set maximum pressure
-        
+
         if max_press is None:
             self.max_press = 1e3
         else:

--- a/species/util/phot_util.py
+++ b/species/util/phot_util.py
@@ -383,7 +383,7 @@ def get_residuals(
                         model_spec = box.create_box(
                             boxtype="model",
                             model=spectrum,
-                            wavelength=model_spec_0.wavelength,
+                            wavelength=wl_new,
                             flux=flux_comb,
                             parameters=parameters,
                             quantity="flux",

--- a/species/util/plot_util.py
+++ b/species/util/plot_util.py
@@ -178,9 +178,25 @@ def update_labels(param: List[str]) -> List[str]:
         index = param.index("teff")
         param[index] = r"$\mathregular{T}_\mathregular{eff}$ (K)"
 
+    if "teff_0" in param:
+        index = param.index("teff_0")
+        param[index] = r"$\mathregular{T}_\mathregular{eff,1}$ (K)"
+
+    if "teff_1" in param:
+        index = param.index("teff_1")
+        param[index] = r"$\mathregular{T}_\mathregular{eff,2}$ (K)"
+
     if "logg" in param:
         index = param.index("logg")
         param[index] = r"$\mathregular{log}\,\mathregular{g}$"
+
+    if "logg_0" in param:
+        index = param.index("logg_0")
+        param[index] = r"$\mathregular{log}\,\mathregular{g}_\mathregular{1}$"
+
+    if "logg_1" in param:
+        index = param.index("logg_1")
+        param[index] = r"$\mathregular{log}\,\mathregular{g}_\mathregular{2}$"
 
     if "metallicity" in param:
         index = param.index("metallicity")
@@ -189,6 +205,14 @@ def update_labels(param: List[str]) -> List[str]:
     if "feh" in param:
         index = param.index("feh")
         param[index] = r"[Fe/H]"
+
+    if "feh_0" in param:
+        index = param.index("feh_0")
+        param[index] = r"[Fe/H]$_\mathregular{1}$"
+
+    if "feh_1" in param:
+        index = param.index("feh_1")
+        param[index] = r"[Fe/H]$_\mathregular{2}$"
 
     if "fsed" in param:
         index = param.index("fsed")
@@ -477,9 +501,7 @@ def update_labels(param: List[str]) -> List[str]:
 
     if "log_p_base" in param:
         index = param.index("log_p_base")
-        param[
-            index
-        ] = r"$\mathregular{{log}}\,\mathregular{{P}}_\mathregular{{cloud}}$"
+        param[index] = r"$\mathregular{{log}}\,\mathregular{{P}}_\mathregular{{cloud}}$"
 
     if "albedo" in param:
         index = param.index("albedo")
@@ -492,6 +514,10 @@ def update_labels(param: List[str]) -> List[str]:
     if "mix_length" in param:
         index = param.index("mix_length")
         param[index] = r"$\ell_\mathregular{m}$ (H$_\mathregular{p}$)"
+
+    if "spec_weight" in param:
+        index = param.index("spec_weight")
+        param[index] = r"w$_\mathregular{spec}$"
 
     return param
 
@@ -645,7 +671,13 @@ def quantity_unit(
     for i in range(100):
         if f"radius_{i}" in param:
             quantity.append(f"radius_{i}")
-            unit.append(r"$\mathregular{R}_\mathregular{J}$")
+
+            if object_type == "planet":
+                unit.append(r"$\mathregular{R}_\mathregular{J}$")
+
+            elif object_type == "star":
+                unit.append(r"$\mathregular{R}_\mathregular{\odot}$")
+
             label.append(rf"$\mathregular{{R}}_\mathregular{{{i+1}}}$")
 
         else:

--- a/species/util/read_util.py
+++ b/species/util/read_util.py
@@ -670,7 +670,4 @@ def binary_to_single(param_dict: Dict[str, float], star_index: int) -> Dict[str,
         elif key in ["teff", "logg", "feh", "c_o_ratio", "fsed", "radius", "distance"]:
             new_dict[key] = value
 
-    # if "radius" in new_dict:
-    #     new_dict["distance"] = param_dict["distance"]
-
     return new_dict

--- a/species/util/read_util.py
+++ b/species/util/read_util.py
@@ -153,9 +153,133 @@ def update_spectra(
         value(s) of the flux scaling and/or the error inflation.
     model : str, None
         Name of the atmospheric model. Only required for inflating the
-        errors. Otherwise, the argument can be set to ``None``. Not
-        required when ``model='petitradtrans'`` because the error
-        inflation is differently implemented with
+        errors of spectra. Otherwise, the argument can be set to
+        ``None``. Not required when ``model='petitradtrans'`` because
+        the error inflation is differently implemented with
+        :class:`~species.analysis.retrieval.AtmosphericRetrieval`.
+
+    Returns
+    -------
+    species.core.box.ObjectBox
+        The input box which includes the spectra with the scaled fluxes
+        and/or inflated errors.
+    """
+
+    warnings.warn(
+        "The update_spectra function is deprecated and "
+        "will be remove in a future release. Please use "
+        "the update_objectbox function instead.",
+        DeprecationWarning,
+    )
+
+    if objectbox.flux is not None:
+
+        for key, value in objectbox.flux.items():
+            if f"{key}_error" in model_param:
+                var_add = model_param[f"{key}_error"] ** 2 * value[0] ** 2
+
+                message = (
+                    f"Inflating the error of {key} "
+                    + f"(W m-2 um-1): {np.sqrt(var_add):.2e}..."
+                )
+
+                print(message, end="", flush=True)
+
+                value[1] = np.sqrt(value[1] ** 2 + var_add)
+
+                print(" [DONE]")
+
+            objectbox.flux[key] = value
+
+    if objectbox.spectrum is not None:
+        # Check if there are any spectra
+
+        for key, value in objectbox.spectrum.items():
+            # Get the spectrum (3 columns)
+            spec_tmp = value[0]
+
+            if f"scaling_{key}" in model_param:
+                # Scale the flux of the spectrum
+                scaling = model_param[f"scaling_{key}"]
+
+                print(
+                    f"Scaling the flux of {key}: {scaling:.2f}...", end="", flush=True
+                )
+                spec_tmp[:, 1] *= model_param[f"scaling_{key}"]
+                print(" [DONE]")
+
+            if f"error_{key}" in model_param:
+                if model is None:
+                    warnings.warn(
+                        f"The dictionary with model parameters contains the error "
+                        f"inflation for {key} but the argument of 'model' is set "
+                        f"to None. Inflation of the errors is therefore not possible."
+                    )
+
+                if model == "petitradtrans":
+                    # Increase the errors by a constant value
+                    add_error = 10.0 ** model_param[f"error_{key}"]
+                    log_msg = (
+                        f"Inflating the error of {key} (W m-2 um-1): {add_error:.2e}..."
+                    )
+
+                    print(log_msg, end="", flush=True)
+                    spec_tmp[:, 2] += add_error
+                    print(" [DONE]")
+
+                else:
+                    # Calculate the model spectrum
+                    wavel_range = (0.9 * spec_tmp[0, 0], 1.1 * spec_tmp[-1, 0])
+                    readmodel = read_model.ReadModel(model, wavel_range=wavel_range)
+
+                    model_box = readmodel.get_model(
+                        model_param,
+                        spec_res=value[3],
+                        wavel_resample=spec_tmp[:, 0],
+                        smooth=True,
+                    )
+
+                    # Scale the errors relative to the model spectrum
+                    err_scaling = model_param[f"error_{key}"]
+                    log_msg = f"Inflating the error of {key}: {err_scaling:.2e}..."
+
+                    print(log_msg, end="", flush=True)
+                    spec_tmp[:, 2] = np.sqrt(
+                        spec_tmp[:, 2] ** 2 + (err_scaling * model_box.flux) ** 2
+                    )
+                    print(" [DONE]")
+
+            # Store the spectra with the scaled fluxes and/or errors
+            # The other three elements (i.e. the covariance matrix,
+            # the inverted covariance matrix, and the spectral
+            # resolution) remain unaffected
+            objectbox.spectrum[key] = (spec_tmp, value[1], value[2], value[3])
+
+    return objectbox
+
+
+@typechecked
+def update_objectbox(
+    objectbox: box.ObjectBox, model_param: Dict[str, float], model: Optional[str] = None
+) -> box.ObjectBox:
+    """
+    Function for updating the spectra and/or photometric fluxes in
+    an :class:`~species.core.box.ObjectBox`, for example by applying
+    a flux scaling and/or error inflation.
+
+    Parameters
+    ----------
+    objectbox : species.core.box.ObjectBox
+        Box with the object's data, including the spectra and/or
+        photometric fluxes.
+    model_param : dict
+        Dictionary with the model parameters. Should contain the
+        value(s) of the flux scaling and/or the error inflation.
+    model : str, None
+        Name of the atmospheric model. Only required for inflating the
+        errors of spectra. Otherwise, the argument can be set to
+        ``None``. Not required when ``model='petitradtrans'`` because
+        the error inflation is differently implemented with
         :class:`~species.analysis.retrieval.AtmosphericRetrieval`.
 
     Returns
@@ -168,17 +292,26 @@ def update_spectra(
     if objectbox.flux is not None:
 
         for key, value in objectbox.flux.items():
+            instr_name = key.split(".")[0]
+
             if f"{key}_error" in model_param:
+                # Inflate photometric error of filter
                 var_add = model_param[f"{key}_error"] ** 2 * value[0] ** 2
 
-                message = f"Inflating the error of {key} " + \
-                          f"(W m-2 um-1): {np.sqrt(var_add):.2e}..."
+            elif f"{instr_name}_error" in model_param:
+                # Inflate photometric error of instrument
+                var_add = model_param[f"{instr_name}_error"] ** 2 * value[0] ** 2
 
-                print(message, end="", flush=True)
+            message = (
+                f"Inflating the error of {key} "
+                + f"(W m-2 um-1): {np.sqrt(var_add):.2e}..."
+            )
 
-                value[1] = np.sqrt(value[1] ** 2 + var_add)
+            print(message, end="", flush=True)
 
-                print(" [DONE]")
+            value[1] = np.sqrt(value[1] ** 2 + var_add)
+
+            print(" [DONE]")
 
             objectbox.flux[key] = value
 
@@ -500,3 +633,44 @@ def gaussian_spectrum(
     )
 
     return model_box
+
+
+@typechecked
+def binary_to_single(param_dict: Dict[str, float], star_index: int) -> Dict[str, float]:
+    """
+    Function for converting a dictionary with atmospheric parameters
+    of a binary system to a dictionary of parameters for one of the
+    two stars.
+
+    Parameters
+    ----------
+    param_dict : dict
+        Dictionary with the atmospheric parameters of both stars. The
+        keywords end either with ``_0`` or ``_1`` that correspond with
+        ``star_index=0`` or ``star_index=1``.
+    star_index : int
+        Star index (0 or 1) that is used for the parameters in
+        ``param_dict``.
+
+    Returns
+    -------
+    dict
+        Dictionary with the parameters of the selected star.
+    """
+
+    new_dict = {}
+
+    for key, value in param_dict.items():
+        if star_index == 0 and key[-1] == "0":
+            new_dict[key[:-2]] = value
+
+        elif star_index == 1 and key[-1] == "1":
+            new_dict[key[:-2]] = value
+
+        elif key in ["teff", "logg", "feh", "c_o_ratio", "fsed", "radius", "distance"]:
+            new_dict[key] = value
+
+    # if "radius" in new_dict:
+    #     new_dict["distance"] = param_dict["distance"]
+
+    return new_dict

--- a/species/util/retrieval_util.py
+++ b/species/util/retrieval_util.py
@@ -1271,7 +1271,11 @@ def calc_spectrum_clouds(
         else:
             contr_em = None
 
-    if plotting and Kzz_use is None and hasattr(rt_object, "ret_test_cloud_scat_plus_abs"):
+    if (
+        plotting
+        and Kzz_use is None
+        and hasattr(rt_object, "ret_test_cloud_scat_plus_abs")
+    ):
         scat_opa = rt_object.ret_test_cloud_scat_plus_abs - rt_object.ret_test_cloud_abs
         plt.plot(
             wavel, rt_object.ret_test_cloud_scat_plus_abs[:, 0], label="Total opacity"
@@ -2568,8 +2572,12 @@ def convective_flux(
     """
 
     t_transp = (f_bol / constants.SIGMA_SB) ** 0.25  # (K)
-    nabla_rad = 3.0 * kappa_r * press * t_transp ** 4.0 / 16.0 / gravity / temp ** 4.0  # (dimensionless)
-    h_press = constants.BOLTZMANN * temp / (mmw * constants.ATOMIC_MASS * gravity)  # (m)
+    nabla_rad = (
+        3.0 * kappa_r * press * t_transp ** 4.0 / 16.0 / gravity / temp ** 4.0
+    )  # (dimensionless)
+    h_press = (
+        constants.BOLTZMANN * temp / (mmw * constants.ATOMIC_MASS * gravity)
+    )  # (m)
     l_mix = mix_length * h_press  # (m)
 
     U = (
@@ -2611,6 +2619,6 @@ def convective_flux(
         * (nabla - nabla_e) ** 1.5
     )
 
-    f_conv[np.isnan(f_conv)] = 0.
+    f_conv[np.isnan(f_conv)] = 0.0
 
     return f_conv  # (W m-2)

--- a/tests/test_read/test_object.py
+++ b/tests/test_read/test_object.py
@@ -24,7 +24,9 @@ class TestObject:
 
     def test_read_object(self):
         database = species.Database()
-        database.add_companion(name="beta Pic b")
+
+        with pytest.warns(UserWarning):
+            database.add_companion(name="beta Pic b")
 
         read_object = species.ReadObject("beta Pic b")
         assert read_object.object_name == "beta Pic b"


### PR DESCRIPTION
- Support for fitting data of blended stars/companions with `FitModel`. Prior boundaries can be provided twice for each atmospheric parameter. If a single range is provided, the parameters are assumed to be the same for both components. The latter can be useful to model a single object with a combination of two parameters (e.g. to account for atmospheric asymmetries) while some other parameters have the same value (e.g. log(g), radius). Functions such as `get_mcmc_spectra`, `multi_photometry`, and `get_residuals` are compatible with blended atmosphere parameters.

- Added the `binary_spectrum` method to `ReadModel`, which is similar to `get_model`, but returns a `ModelBox` for a `model_param` dictionary with blended atmosphere parameters.

- In addition to fitting an error inflation for a single filter by adding `_error` to the filter name  in `bounds` of `FitModel` (e.g. `2MASS/2MASS.J_error: (0., 1.)`), it is now also possible fit to fit a single inflation per instrument. In that case, the filter name (i.e. the part after, and including, the dot) is removed, for example `2MASS/2MASS_error`: (0., 1.)` will fit the same error inflation to any of the 2MASS filters that is included with `inc_phot`.

- The following example shows how to fit a blended spectrum with an instrument-specific inflation of the photometric errors. In this case, [Fe/H] is fixed to solar for both components and the full grid range is used as priors of log(g):

```
fit = species.FitModel(object_name='binary star',
                       model='bt-nextgen',
                       bounds={'teff': ((4000., 15000.), (4000., 15000.)),
                               'logg': (None, None),
                               'feh': ((0., 0.), (0., 0.)),
                               'radius': ((10., 20.), (10., 20.)),
                               '2MASS/2MASS_error': (0., 1.)},
                       inc_phot=True,
                       inc_spec=False)
```

- Added the `synthetic_photometry` method to `ModelBox`, which returns a `PhotometryBox` with synthetic photometry for a given `filter_name`. The `PhotometryBox` can be directly provided to `boxes` of `plot_spectrum`.

-  The `output` parameter of all plotting function can be set to `None` in order to show a window with the plot instead of writing the plot to an output file.

- Changed `update_spectra` to `update_objectbox`. The first is still available but will be deprecated in a future release. The latter supports the inflation of photometric errors after fitting the `_error` parameter with `FitModel`.
