### PR TITLE
Small fixes

### DIFF
--- a/species/plot/plot_mcmc.py
+++ b/species/plot/plot_mcmc.py
@@ -404,7 +404,7 @@ def plot_posterior(
             o_h_ratio = np.zeros(samples.shape[0])
             c_o_ratio = np.zeros(samples.shape[0])
 
-            for sample_item in samples:
+            for i,sample_item in enumerate(samples):
                 abund_dict = {}
                 for line_item in line_species:
                     abund_dict[line_item] = sample_item[abund_index[line_item]]

--- a/species/util/radtrans_util.py
+++ b/species/util/radtrans_util.py
@@ -195,9 +195,9 @@ def retrieval_spectrum(
             model_param["albedo"] = sample[indices["albedo"]]
 
     elif len(cloud_species) > 0:
-        try:
+        if "fsed" in indices:
             model_param["fsed"] = sample[indices["fsed"]]
-        except KeyError:
+        else:
             for item in cloud_species:
                 model_param[f"fsed_{item}"] = sample[indices[f"fsed_{item}"]]
         model_param["sigma_lnorm"] = sample[indices["sigma_lnorm"]]

--- a/species/util/radtrans_util.py
+++ b/species/util/radtrans_util.py
@@ -195,7 +195,11 @@ def retrieval_spectrum(
             model_param["albedo"] = sample[indices["albedo"]]
 
     elif len(cloud_species) > 0:
-        model_param["fsed"] = sample[indices["fsed"]]
+        try:
+            model_param["fsed"] = sample[indices["fsed"]]
+        except KeyError:
+            for item in cloud_species:
+                model_param[f"fsed_{item}"] = sample[indices[f"fsed_{item}"]]
         model_param["sigma_lnorm"] = sample[indices["sigma_lnorm"]]
 
         if "kzz" in indices:

--- a/species/util/retrieval_util.py
+++ b/species/util/retrieval_util.py
@@ -900,6 +900,8 @@ def calc_spectrum_clear(
             pressure,
             Pquench_carbon=p_quench,
         )
+        # Extract the mean molecular weight
+        mmw = abund_in["MMW"]
 
     elif chemistry == "free":
         # Free abundances


### PR DESCRIPTION
Hi Tomas, these are a few very small bugs I found in running some retrievals this past month. 

When plotting a free chemistry retrieval, there was no enumerator in the loop so the C/H, O/H, and C/O posteriors were returned with =0. 

When global_fsed was set false, and then post processed to make plots, it would give a KeyError: "fsed", which I handled with the try/except statement (not sure if there is a different way you'd prefer to handle that). 

The mmw wasn't established in the chemical equilibrium portion of the clear spectrum generator. 