### PR TITLE
small bugfix in setup_retrieval without spectra

### DIFF
--- a/species/fit/retrieval.py
+++ b/species/fit/retrieval.py
@@ -3583,7 +3583,8 @@ class AtmosphericRetrieval:
 
         for spec_value in self.spectrum.values():
             data_spec_res.append(spec_value[3])
-
+        if len(data_spec_res) == 0:
+            data_spec_res.append(40) # for photometry only retrievals
         max_spec_res = max(data_spec_res)
 
         if max_spec_res > 1000.0 and self.res_mode == "c-k":


### PR DESCRIPTION
For cases where there is dense photometry but not spectroscopy, one may still want to run a retrieval. This tiny bugfix patches an instance where a breaking error would be thrown by setup_retrieval when inc_spec=False and the list data_spec_res is empty.