### PR TITLE
Add nircam bar photometry from Balmer et al. 2025b

### DIFF
--- a/species/data/companion_data/companion_data.json
+++ b/species/data/companion_data/companion_data.json
@@ -293,6 +293,10 @@
                 16.2,
                 0.11
             ],
+            "JWST/NIRCAM.F410M": [
+                15.8,
+                0.10
+            ],
             "Keck/NIRC2.Ms": [
                 16.1,
                 0.5
@@ -318,6 +322,7 @@
             6.0
         ],
         "references": [
+            "Balmer et al. 2025b",
             "Dupuy et al. 2022",
             "Gaia Early Data Release 3",
             "Maire et al. 2019",
@@ -378,7 +383,17 @@
             "Keck/NIRC2.Ms": [
                 16.05,
                 0.3
-            ]
+            ],
+            "JWST/NIRCAM.F182M":[18.66,0.11],
+            "JWST/NIRCAM.F200W":[17.76,0.06],
+            "JWST/NIRCAM.F210M":[17.39,0.05],
+            "JWST/NIRCAM.F250M":[18.19,0.17],
+            "JWST/NIRCAM.F300M":[17.37,0.04],
+            "JWST/NIRCAM.F335M":[16.20,0.05],
+            "JWST/NIRCAM.F410M":[15.25,0.04],
+            "JWST/NIRCAM.F430M":[16.04,0.10],
+            "JWST/NIRCAM.F460M":[16.01,0.13]
+
         },
         "semi_major": [
             71.3,
@@ -401,6 +416,7 @@
         ],
         "references": [
             "Baines et al. 2012",
+            "Balmer et al. 2025b",
             "Currie et al. 2011",
             "Currie et al. 2012",
             "Currie et al. 2014",
@@ -459,7 +475,15 @@
             "Keck/NIRC2.Ms": [
                 15.03,
                 0.14
-            ]
+            ],
+            "JWST/NIRCAM.F200W":[17.46,0.13],
+            "JWST/NIRCAM.F210M":[16.73,0.10],
+            "JWST/NIRCAM.F250M":[16.95,0.20],
+            "JWST/NIRCAM.F300M":[16.49,0.09],
+            "JWST/NIRCAM.F335M":[15.34,0.12],
+            "JWST/NIRCAM.F410M":[14.85,0.09],
+            "JWST/NIRCAM.F430M":[15.19,0.05],
+            "JWST/NIRCAM.F460M":[15.17,0.08]
         },
         "semi_major": [
             41.0,
@@ -482,6 +506,7 @@
         ],
         "references": [
             "Baines et al. 2012",
+            "Balmer et al. 2025b",
             "Currie et al. 2012",
             "Currie et al. 2014",
             "Gaia Early Data Release 3",
@@ -539,7 +564,13 @@
             "Keck/NIRC2.Ms": [
                 14.65,
                 0.35
-            ]
+            ],
+            "JWST/NIRCAM.F250M":[16.65,0.14],
+            "JWST/NIRCAM.F300M":[15.78,0.09],
+            "JWST/NIRCAM.F335M":[14.81,0.05],
+            "JWST/NIRCAM.F410M":[14.26,0.04],
+            "JWST/NIRCAM.F430M":[14.32,0.05],
+            "JWST/NIRCAM.F460M":[14.27,0.06]
         },
         "semi_major": [
             26.55,
@@ -562,6 +593,7 @@
         ],
         "references": [
             "Baines et al. 2012",
+            "Balmer et al. 2025b",
             "Currie et al. 2012",
             "Currie et al. 2014",
             "Gaia Early Data Release 3",
@@ -611,7 +643,11 @@
             "Paranal/NACO.NB405": [
                 13.72,
                 0.2
-            ]
+            ],
+            "JWST/NIRCAM.F335M":[15.49,0.16],
+            "JWST/NIRCAM.F410M":[14.77,0.16],
+            "JWST/NIRCAM.F430M":[15.21,0.12],
+            "JWST/NIRCAM.F460M":[15.03,0.11]
         },
         "semi_major": [
             16.0,
@@ -634,6 +670,7 @@
         ],
         "references": [
             "Baines et al. 2012",
+            "Balmer et al. 2025b",
             "Currie et al. 2014",
             "Gaia Early Data Release 3",
             "Marois et al. 2010",


### PR DESCRIPTION
Hi Tomas! This addition includes the 3-5 micron photometry of the HR 8799 and 51 Eri planets from our recent JWST paper (https://doi.org/10.3847/1538-3881/adb1c6). 